### PR TITLE
Correção de erro de segurança (XSS)

### DIFF
--- a/src/components/StreamChat.vue
+++ b/src/components/StreamChat.vue
@@ -34,9 +34,20 @@ export default {
       setTimeout(() => this.$refs.messageWrapper?.classList.add('visible'), 100)
     });
   },
+  methods: {
+		/**
+		 * @description This function replaces all < and > with safe HTML characters to prevent XSS attacks
+		 * @param {string} message
+		 * @returns {string}
+		 * */
+		sanitizeMessage(message) {
+			return message.replace(/</g, '&lt;').replace(/>/g, '&gt;');
+		}
+	},
   computed: {
     messageWithEmotes() {
-      let message = this.message
+      let message = this.sanitizeMessage(this.message)
+
       const messageEmotes = this.extra.emotes
       const replaceBetween = ({start, end, img, message}) => message.substring(0, start) + img + message.substring(end);
       const imgEmote = (src) => `<img class="inline-block w-8" src="${src}"/>`


### PR DESCRIPTION
# Descrição do problema

Ataques XSS são bem simples: o usuário envia um conteúdo contendo um código HTML e este código é interpretado pelo navegador, podendo executar algum script malicioso. Por padrão o Vue já trata isso quando usamos textos no template dos componentes, mas usar a diretiva `v-html` abre essa brecha de segurança para nós.

Para verificar o erro, basta colar o seguinte código em algum arquivo na aplicação antes de aplicar as alterações dessa PR:

```ts
store.chat.messages.push({
  channel: '',
  user: 'usuário malicioso',
  message: '<img src="" onerror="alert(\'XSS realizado com sucesso💀🔓\')" / >',
  extra: { emotes: [] }
})
```

Esse código basicamente vai adicionar uma mensagem com um script malicioso na lista de mensagens, e quando ela for renderizada vamos ver um alerta na tela com a mensagem acima. Obviamente um alerta não é nada de mais, mas algum usuário poderia enviar uma mensagem no chat com um loop infinito ou que tenta acessar alguma informação em localStorage, acessar cookies inseguros etc.

A correção disso foi simples: assim que uma mensagem é passada para o calback da computed `messageWithEmotes` nós sanitizamos ela com a função `sanitizeMessage`, que vai tornar todos os caracteres `<` e `>` em caracteres similares, mas que não geram tags HTMLs. Isso vai sanitizar todo o conteúdo não confiável da string, e então podemos aplicar as alterações que quisermos nessa mensagem, pois sabemos que os códigos HTML que estamos adicionando à string são seguros.

----

Essa correção é parte da PR #1, mas isolei ela aqui pois é uma correção importante e mais pontual, não dependendo das outras alterações que fiz naquela PR