### PR TITLE
Adição e e configuração de linter e formatador de código

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,37 @@
+/* eslint-env node */
+require('@rushstack/eslint-patch/modern-module-resolution')
+module.exports = {
+	root: true,
+	env: {
+		browser: true,
+		es2021: true,
+		node: true
+	},
+	extends: [
+		'@vue/eslint-config-typescript',
+		'@vue/eslint-config-prettier',
+		'eslint:recommended',
+		'plugin:vue/vue3-essential',
+		'plugin:@typescript-eslint/recommended',
+		'prettier'
+	],
+	parser: 'vue-eslint-parser',
+	parserOptions: {
+		parser: {
+			ts: '@typescript-eslint/parser',
+			'<template>': 'espree'
+		},
+		ecmaVersion: 'latest',
+		sourceType: 'module'
+	},
+	plugins: ['vue', '@typescript-eslint'],
+	rules: {
+		indent: ['error', 'tab'],
+		'linebreak-style': ['error', 'unix'],
+		quotes: ['error', 'single'],
+		semi: ['error', 'never'],
+		'@typescript-eslint/no-non-null-assertion': 'off',
+		'@typescript-eslint/no-explicit-any': 'off',
+		'no-undef': 'off'
+	}
+}

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,37 +1,37 @@
 /* eslint-env node */
 require('@rushstack/eslint-patch/modern-module-resolution')
 module.exports = {
-	root: true,
-	env: {
-		browser: true,
-		es2021: true,
-		node: true
-	},
-	extends: [
-		'@vue/eslint-config-typescript',
-		'@vue/eslint-config-prettier',
-		'eslint:recommended',
-		'plugin:vue/vue3-essential',
-		'plugin:@typescript-eslint/recommended',
-		'prettier'
-	],
-	parser: 'vue-eslint-parser',
-	parserOptions: {
-		parser: {
-			ts: '@typescript-eslint/parser',
-			'<template>': 'espree'
-		},
-		ecmaVersion: 'latest',
-		sourceType: 'module'
-	},
-	plugins: ['vue', '@typescript-eslint'],
-	rules: {
-		indent: ['error', 'tab'],
-		'linebreak-style': ['error', 'unix'],
-		quotes: ['error', 'single'],
-		semi: ['error', 'never'],
-		'@typescript-eslint/no-non-null-assertion': 'off',
-		'@typescript-eslint/no-explicit-any': 'off',
-		'no-undef': 'off'
-	}
+  root: true,
+  env: {
+    browser: true,
+    es2021: true,
+    node: true
+  },
+  extends: [
+    '@vue/eslint-config-typescript',
+    '@vue/eslint-config-prettier',
+    'eslint:recommended',
+    'plugin:vue/vue3-essential',
+    'plugin:@typescript-eslint/recommended',
+    'prettier'
+  ],
+  parser: 'vue-eslint-parser',
+  parserOptions: {
+    parser: {
+      ts: '@typescript-eslint/parser',
+      '<template>': 'espree'
+    },
+    ecmaVersion: 'latest',
+    sourceType: 'module'
+  },
+  plugins: ['vue', '@typescript-eslint'],
+  rules: {
+    indent: ['error', 2],
+    'linebreak-style': ['error', 'unix'],
+    quotes: ['error', 'single'],
+    semi: ['error', 'never'],
+    '@typescript-eslint/no-non-null-assertion': 'off',
+    '@typescript-eslint/no-explicit-any': 'off',
+    'no-undef': 'off'
+  }
 }

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,8 @@
+{
+	"trailingComma": "none",
+	"useTabs": true,
+	"tabWidth": 2,
+	"semi": false,
+	"singleQuote": true,
+	"arrowParens": "avoid"
+}

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,6 +1,6 @@
 {
 	"trailingComma": "none",
-	"useTabs": true,
+	"useTabs": false,
 	"tabWidth": 2,
 	"semi": false,
 	"singleQuote": true,

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,9 +6,9 @@ import node from '@astrojs/node'
 
 // https://astro.build/config
 export default defineConfig({
-	output: 'server',
-	integrations: [tailwind(), vue()],
-	adapter: node({
-		mode: 'standalone'
-	})
+  output: 'server',
+  integrations: [tailwind(), vue()],
+  adapter: node({
+    mode: 'standalone'
+  })
 })

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,14 +1,14 @@
-import { defineConfig } from 'astro/config';
-import tailwind from "@astrojs/tailwind";
-import vue from "@astrojs/vue";
+import { defineConfig } from 'astro/config'
+import tailwind from '@astrojs/tailwind'
+import vue from '@astrojs/vue'
 
-import node from "@astrojs/node";
+import node from '@astrojs/node'
 
 // https://astro.build/config
 export default defineConfig({
-  output: 'server',
-  integrations: [tailwind(), vue()],
-  adapter: node({
-    mode: "standalone"
-  })
-});
+	output: 'server',
+	integrations: [tailwind(), vue()],
+	adapter: node({
+		mode: 'standalone'
+	})
+})

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "preview": "astro preview",
     "astro": "astro",
     "serve": "HOST=0.0.0.0 PORT=8485 node ./dist/server/entry.mjs",
-    "ws": "node src/ws.js"
+    "ws": "node src/ws.js",
+    "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --fix --ignore-path .gitignore",
+    "lint:fix": "pnpm run lint --fix"
   },
   "dependencies": {
     "@astrojs/check": "^0.4.1",
@@ -31,6 +33,12 @@
     "vue": "^3.4.15"
   },
   "devDependencies": {
-    "@types/tmi.js": "^1.8.6"
+    "@rushstack/eslint-patch": "^1.7.2",
+    "@types/tmi.js": "^1.8.6",
+    "@vue/eslint-config-prettier": "^9.0.0",
+    "@vue/eslint-config-typescript": "^12.0.0",
+    "eslint": "^8.57.0",
+    "eslint-plugin-vue": "^9.22.0",
+    "prettier": "3.2.5"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 dependencies:
   '@astrojs/check':
     specifier: ^0.4.1
-    version: 0.4.1(typescript@5.3.3)
+    version: 0.4.1(prettier@3.2.5)(typescript@5.3.3)
   '@astrojs/node':
     specifier: ^8.2.0
     version: 8.2.0(astro@4.2.4)
@@ -58,11 +58,34 @@ dependencies:
     version: 3.4.15(typescript@5.3.3)
 
 devDependencies:
+  '@rushstack/eslint-patch':
+    specifier: ^1.7.2
+    version: 1.7.2
   '@types/tmi.js':
     specifier: ^1.8.6
     version: 1.8.6
+  '@vue/eslint-config-prettier':
+    specifier: ^9.0.0
+    version: 9.0.0(eslint@8.57.0)(prettier@3.2.5)
+  '@vue/eslint-config-typescript':
+    specifier: ^12.0.0
+    version: 12.0.0(eslint-plugin-vue@9.22.0)(eslint@8.57.0)(typescript@5.3.3)
+  eslint:
+    specifier: ^8.57.0
+    version: 8.57.0
+  eslint-plugin-vue:
+    specifier: ^9.22.0
+    version: 9.22.0(eslint@8.57.0)
+  prettier:
+    specifier: 3.2.5
+    version: 3.2.5
 
 packages:
+
+  /@aashutoshrathi/word-wrap@1.2.6:
+    resolution: {integrity: sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==}
+    engines: {node: '>=0.10.0'}
+    dev: true
 
   /@alloc/quick-lru@5.2.0:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -77,13 +100,13 @@ packages:
       '@jridgewell/trace-mapping': 0.3.22
     dev: false
 
-  /@astrojs/check@0.4.1(typescript@5.3.3):
+  /@astrojs/check@0.4.1(prettier@3.2.5)(typescript@5.3.3):
     resolution: {integrity: sha512-XEsuU4TlWkgcsvdeessq5mXLXV1fejtxIioCPv/FfhTzb1bDYe2BtLiSBK+rFTyD9Hl686YOas9AGNMJcpoRsw==}
     hasBin: true
     peerDependencies:
       typescript: ^5.0.0
     dependencies:
-      '@astrojs/language-server': 2.6.2(typescript@5.3.3)
+      '@astrojs/language-server': 2.6.2(prettier@3.2.5)(typescript@5.3.3)
       chokidar: 3.5.3
       fast-glob: 3.3.2
       kleur: 4.1.5
@@ -102,7 +125,7 @@ packages:
     resolution: {integrity: sha512-06DD2ZnItMwUnH81LBLco3tWjcZ1lGU9rLCCBaeUCGYe9cI0wKyY2W3kDyoW1I6GmcWgt1fu+D1CTvz+FIKf8A==}
     dev: false
 
-  /@astrojs/language-server@2.6.2(typescript@5.3.3):
+  /@astrojs/language-server@2.6.2(prettier@3.2.5)(typescript@5.3.3):
     resolution: {integrity: sha512-RYzPRhS/WBXK5JtfR+0+nGj+N3VbJd5jU/uSNUev9baUx/RLmUwDk1f6Oy8QDEfDDLAr76Ig8YeDD/nxPdBSLw==}
     hasBin: true
     peerDependencies:
@@ -124,10 +147,11 @@ packages:
       '@volar/typescript': 1.11.1
       fast-glob: 3.3.2
       muggle-string: 0.3.1
+      prettier: 3.2.5
       volar-service-css: 0.0.17(@volar/language-service@1.11.1)
       volar-service-emmet: 0.0.17(@volar/language-service@1.11.1)
       volar-service-html: 0.0.17(@volar/language-service@1.11.1)
-      volar-service-prettier: 0.0.17(@volar/language-service@1.11.1)
+      volar-service-prettier: 0.0.17(@volar/language-service@1.11.1)(prettier@3.2.5)
       volar-service-typescript: 0.0.17(@volar/language-service@1.11.1)(@volar/typescript@1.11.1)
       volar-service-typescript-twoslash-queries: 0.0.17(@volar/language-service@1.11.1)
       vscode-html-languageservice: 5.1.2
@@ -749,6 +773,63 @@ packages:
     dev: false
     optional: true
 
+  /@eslint-community/eslint-utils@4.4.0(eslint@8.57.0):
+    resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+    dependencies:
+      eslint: 8.57.0
+      eslint-visitor-keys: 3.4.3
+    dev: true
+
+  /@eslint-community/regexpp@4.10.0:
+    resolution: {integrity: sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+    dev: true
+
+  /@eslint/eslintrc@2.1.4:
+    resolution: {integrity: sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      ajv: 6.12.6
+      debug: 4.3.4
+      espree: 9.6.1
+      globals: 13.24.0
+      ignore: 5.3.1
+      import-fresh: 3.3.0
+      js-yaml: 4.1.0
+      minimatch: 3.1.2
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@eslint/js@8.57.0:
+    resolution: {integrity: sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dev: true
+
+  /@humanwhocodes/config-array@0.11.14:
+    resolution: {integrity: sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==}
+    engines: {node: '>=10.10.0'}
+    dependencies:
+      '@humanwhocodes/object-schema': 2.0.2
+      debug: 4.3.4
+      minimatch: 3.1.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@humanwhocodes/module-importer@1.0.1:
+    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
+    engines: {node: '>=12.22'}
+    dev: true
+
+  /@humanwhocodes/object-schema@2.0.2:
+    resolution: {integrity: sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==}
+    dev: true
+
   /@isaacs/cliui@8.0.2:
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
@@ -815,12 +896,10 @@ packages:
     dependencies:
       '@nodelib/fs.stat': 2.0.5
       run-parallel: 1.2.0
-    dev: false
 
   /@nodelib/fs.stat@2.0.5:
     resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
     engines: {node: '>= 8'}
-    dev: false
 
   /@nodelib/fs.walk@1.2.8:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
@@ -828,7 +907,6 @@ packages:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.16.0
-    dev: false
 
   /@pkgjs/parseargs@0.11.0:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -836,6 +914,11 @@ packages:
     requiresBuild: true
     dev: false
     optional: true
+
+  /@pkgr/core@0.1.1:
+    resolution: {integrity: sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==}
+    engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+    dev: true
 
   /@rollup/rollup-android-arm-eabi@4.9.6:
     resolution: {integrity: sha512-MVNXSSYN6QXOulbHpLMKYi60ppyO13W9my1qogeiAqtjb2yR4LSmfU2+POvDkLzhjYLXz9Rf9+9a3zFHW1Lecg==}
@@ -941,6 +1024,10 @@ packages:
     dev: false
     optional: true
 
+  /@rushstack/eslint-patch@1.7.2:
+    resolution: {integrity: sha512-RbhOOTCNoCrbfkRyoXODZp75MlpiHMgbE5MEBZAnnnLyQNgrigEj4p0lzsMDyc1zVsJDLrivB58tgg3emX0eEA==}
+    dev: true
+
   /@socket.io/component-emitter@3.1.0:
     resolution: {integrity: sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==}
     dev: false
@@ -1000,6 +1087,10 @@ packages:
       '@types/unist': 3.0.2
     dev: false
 
+  /@types/json-schema@7.0.15:
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+    dev: true
+
   /@types/mdast@4.0.3:
     resolution: {integrity: sha512-LsjtqsyF+d2/yFOYaN22dHZI1Cpwkrj+g06G8+qtUKlhovPW89YhqSnfKtMbkgmEtYpH2gydRNULd6y8mciAFg==}
     dependencies:
@@ -1029,6 +1120,10 @@ packages:
       undici-types: 5.26.5
     dev: false
 
+  /@types/semver@7.5.8:
+    resolution: {integrity: sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==}
+    dev: true
+
   /@types/tmi.js@1.8.6:
     resolution: {integrity: sha512-LVzNK7AxTMyh9qHLanAQR1o0I9XzfbIcXk85cx85igmCJHHO1Sm71sdhQ8Mj1WmRGzynPIoCXx6mVaFynWbsQw==}
     dev: true
@@ -1041,9 +1136,140 @@ packages:
     resolution: {integrity: sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ==}
     dev: false
 
+  /@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0)(eslint@8.57.0)(typescript@5.3.3):
+    resolution: {integrity: sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^6.0.0 || ^6.0.0-alpha
+      eslint: ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@eslint-community/regexpp': 4.10.0
+      '@typescript-eslint/parser': 6.21.0(eslint@8.57.0)(typescript@5.3.3)
+      '@typescript-eslint/scope-manager': 6.21.0
+      '@typescript-eslint/type-utils': 6.21.0(eslint@8.57.0)(typescript@5.3.3)
+      '@typescript-eslint/utils': 6.21.0(eslint@8.57.0)(typescript@5.3.3)
+      '@typescript-eslint/visitor-keys': 6.21.0
+      debug: 4.3.4
+      eslint: 8.57.0
+      graphemer: 1.4.0
+      ignore: 5.3.1
+      natural-compare: 1.4.0
+      semver: 7.5.4
+      ts-api-utils: 1.2.1(typescript@5.3.3)
+      typescript: 5.3.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3):
+    resolution: {integrity: sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    peerDependencies:
+      eslint: ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/scope-manager': 6.21.0
+      '@typescript-eslint/types': 6.21.0
+      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.3.3)
+      '@typescript-eslint/visitor-keys': 6.21.0
+      debug: 4.3.4
+      eslint: 8.57.0
+      typescript: 5.3.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/scope-manager@6.21.0:
+    resolution: {integrity: sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    dependencies:
+      '@typescript-eslint/types': 6.21.0
+      '@typescript-eslint/visitor-keys': 6.21.0
+    dev: true
+
+  /@typescript-eslint/type-utils@6.21.0(eslint@8.57.0)(typescript@5.3.3):
+    resolution: {integrity: sha512-rZQI7wHfao8qMX3Rd3xqeYSMCL3SoiSQLBATSiVKARdFGCYSRvmViieZjqc58jKgs8Y8i9YvVVhRbHSTA4VBag==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    peerDependencies:
+      eslint: ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.3.3)
+      '@typescript-eslint/utils': 6.21.0(eslint@8.57.0)(typescript@5.3.3)
+      debug: 4.3.4
+      eslint: 8.57.0
+      ts-api-utils: 1.2.1(typescript@5.3.3)
+      typescript: 5.3.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/types@6.21.0:
+    resolution: {integrity: sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    dev: true
+
+  /@typescript-eslint/typescript-estree@6.21.0(typescript@5.3.3):
+    resolution: {integrity: sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 6.21.0
+      '@typescript-eslint/visitor-keys': 6.21.0
+      debug: 4.3.4
+      globby: 11.1.0
+      is-glob: 4.0.3
+      minimatch: 9.0.3
+      semver: 7.5.4
+      ts-api-utils: 1.2.1(typescript@5.3.3)
+      typescript: 5.3.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/utils@6.21.0(eslint@8.57.0)(typescript@5.3.3):
+    resolution: {integrity: sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    peerDependencies:
+      eslint: ^7.0.0 || ^8.0.0
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
+      '@types/json-schema': 7.0.15
+      '@types/semver': 7.5.8
+      '@typescript-eslint/scope-manager': 6.21.0
+      '@typescript-eslint/types': 6.21.0
+      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.3.3)
+      eslint: 8.57.0
+      semver: 7.5.4
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
+  /@typescript-eslint/visitor-keys@6.21.0:
+    resolution: {integrity: sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    dependencies:
+      '@typescript-eslint/types': 6.21.0
+      eslint-visitor-keys: 3.4.3
+    dev: true
+
   /@ungap/structured-clone@1.2.0:
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
-    dev: false
 
   /@vitejs/plugin-vue-jsx@3.1.0(vite@5.0.12)(vue@3.4.15):
     resolution: {integrity: sha512-w9M6F3LSEU5kszVb9An2/MmXNxocAnUb3WhRr8bHlimhDrXNt6n6D2nJQR3UXpGlZHh/EsgouOHCsM8V3Ln+WA==}
@@ -1225,6 +1451,41 @@ packages:
       '@vue/shared': 3.4.15
     dev: false
 
+  /@vue/eslint-config-prettier@9.0.0(eslint@8.57.0)(prettier@3.2.5):
+    resolution: {integrity: sha512-z1ZIAAUS9pKzo/ANEfd2sO+v2IUalz7cM/cTLOZ7vRFOPk5/xuRKQteOu1DErFLAh/lYGXMVZ0IfYKlyInuDVg==}
+    peerDependencies:
+      eslint: '>= 8.0.0'
+      prettier: '>= 3.0.0'
+    dependencies:
+      eslint: 8.57.0
+      eslint-config-prettier: 9.1.0(eslint@8.57.0)
+      eslint-plugin-prettier: 5.1.3(eslint-config-prettier@9.1.0)(eslint@8.57.0)(prettier@3.2.5)
+      prettier: 3.2.5
+    transitivePeerDependencies:
+      - '@types/eslint'
+    dev: true
+
+  /@vue/eslint-config-typescript@12.0.0(eslint-plugin-vue@9.22.0)(eslint@8.57.0)(typescript@5.3.3):
+    resolution: {integrity: sha512-StxLFet2Qe97T8+7L8pGlhYBBr8Eg05LPuTDVopQV6il+SK6qqom59BA/rcFipUef2jD8P2X44Vd8tMFytfvlg==}
+    engines: {node: ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.2.0 || ^7.0.0 || ^8.0.0
+      eslint-plugin-vue: ^9.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 6.21.0(@typescript-eslint/parser@6.21.0)(eslint@8.57.0)(typescript@5.3.3)
+      '@typescript-eslint/parser': 6.21.0(eslint@8.57.0)(typescript@5.3.3)
+      eslint: 8.57.0
+      eslint-plugin-vue: 9.22.0(eslint@8.57.0)
+      typescript: 5.3.3
+      vue-eslint-parser: 9.4.2(eslint@8.57.0)
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@vue/reactivity@3.4.15:
     resolution: {integrity: sha512-55yJh2bsff20K5O84MxSvXKPHHt17I2EomHznvFiJCAZpJTNW8IuLj1xZWMLELRhBK3kkFV/1ErZGHJfah7i7w==}
     dependencies:
@@ -1275,11 +1536,18 @@ packages:
       negotiator: 0.6.3
     dev: false
 
+  /acorn-jsx@5.3.2(acorn@8.11.3):
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      acorn: 8.11.3
+    dev: true
+
   /acorn@8.11.3:
     resolution: {integrity: sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
-    dev: false
 
   /agentkeepalive@4.5.0:
     resolution: {integrity: sha512-5GG/5IbQQpC9FpkRGsSvZI5QYeSCzlJHdpBQntCsuTOxhKD8lqKhrleg2Yi7yvMIf82Ycmmqln9U8V9qwEiJew==}
@@ -1287,6 +1555,15 @@ packages:
     dependencies:
       humanize-ms: 1.2.1
     dev: false
+
+  /ajv@6.12.6:
+    resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
+    dev: true
 
   /ansi-align@3.0.1:
     resolution: {integrity: sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==}
@@ -1297,7 +1574,6 @@ packages:
   /ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
-    dev: false
 
   /ansi-regex@6.0.1:
     resolution: {integrity: sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==}
@@ -1316,7 +1592,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       color-convert: 2.0.1
-    dev: false
 
   /ansi-styles@6.2.1:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
@@ -1347,7 +1622,6 @@ packages:
 
   /argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
-    dev: false
 
   /aria-query@5.3.0:
     resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
@@ -1358,6 +1632,11 @@ packages:
   /array-iterate@2.0.1:
     resolution: {integrity: sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg==}
     dev: false
+
+  /array-union@2.1.0:
+    resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
+    engines: {node: '>=8'}
+    dev: true
 
   /astro@4.2.4(typescript@5.3.3):
     resolution: {integrity: sha512-z1f52lXkHf71M5HSLKrd5G1PH5/Zfq4kMp0iUT7Na5VHcPDma/NYFPFPewDxqV6UPmyxupj3xuooFaN3j8zaow==}
@@ -1493,7 +1772,6 @@ packages:
 
   /balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-    dev: false
 
   /base-64@0.1.0:
     resolution: {integrity: sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA==}
@@ -1535,6 +1813,10 @@ packages:
       readable-stream: 3.6.2
     dev: false
 
+  /boolbase@1.0.0:
+    resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+    dev: true
+
   /boxen@7.1.1:
     resolution: {integrity: sha512-2hCgjEmP8YLWQ130n2FerGv7rYpfBmnmp9Uy2Le1vge6X3gZIfSmEzP5QTDElFxcvVcXlEn8Aq6MU/PZygIOog==}
     engines: {node: '>=14.16'}
@@ -1549,18 +1831,23 @@ packages:
       wrap-ansi: 8.1.0
     dev: false
 
+  /brace-expansion@1.1.11:
+    resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+    dev: true
+
   /brace-expansion@2.0.1:
     resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
     dependencies:
       balanced-match: 1.0.2
-    dev: false
 
   /braces@3.0.2:
     resolution: {integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==}
     engines: {node: '>=8'}
     dependencies:
       fill-range: 7.0.1
-    dev: false
 
   /browserslist@4.22.2:
     resolution: {integrity: sha512-0UgcrvQmBDvZHFGdYUehrCNIazki7/lUP3kkoi/r3YB2amZbFM9J43ZRkJTXBUZK4gmx56+Sqk9+Vs9mwZx9+A==}
@@ -1588,6 +1875,11 @@ packages:
       base64-js: 1.5.1
       ieee754: 1.2.1
     dev: false
+
+  /callsites@3.1.0:
+    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
+    dev: true
 
   /camelcase-css@2.0.1:
     resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
@@ -1620,6 +1912,14 @@ packages:
       escape-string-regexp: 1.0.5
       supports-color: 5.5.0
     dev: false
+
+  /chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+    dev: true
 
   /chalk@5.3.0:
     resolution: {integrity: sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==}
@@ -1716,7 +2016,6 @@ packages:
     requiresBuild: true
     dependencies:
       color-name: 1.1.4
-    dev: false
 
   /color-name@1.1.3:
     resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
@@ -1725,7 +2024,6 @@ packages:
   /color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
     requiresBuild: true
-    dev: false
 
   /color-string@1.9.1:
     resolution: {integrity: sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==}
@@ -1777,6 +2075,10 @@ packages:
     resolution: {integrity: sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==}
     dev: false
 
+  /concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+    dev: true
+
   /convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
     dev: false
@@ -1806,7 +2108,6 @@ packages:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
-    dev: false
 
   /crypt@0.0.2:
     resolution: {integrity: sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==}
@@ -1816,7 +2117,6 @@ packages:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
     hasBin: true
-    dev: false
 
   /csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
@@ -1854,7 +2154,6 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.2
-    dev: false
 
   /decode-named-character-reference@1.0.2:
     resolution: {integrity: sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==}
@@ -1877,6 +2176,10 @@ packages:
     requiresBuild: true
     dev: false
     optional: true
+
+  /deep-is@0.1.4:
+    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+    dev: true
 
   /delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
@@ -1938,9 +2241,23 @@ packages:
       md5: 2.3.0
     dev: false
 
+  /dir-glob@3.0.1:
+    resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
+    engines: {node: '>=8'}
+    dependencies:
+      path-type: 4.0.0
+    dev: true
+
   /dlv@1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
     dev: false
+
+  /doctrine@3.0.0:
+    resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
+    engines: {node: '>=6.0.0'}
+    dependencies:
+      esutils: 2.0.3
+    dev: true
 
   /dset@3.1.3:
     resolution: {integrity: sha512-20TuZZHCEZ2O71q9/+8BwKwZ0QtD9D8ObhrihJPr+vLLYlSuAU3/zL4cSlgbfeoGHTjCSJBa7NGcrF9/Bx/WJQ==}
@@ -2084,16 +2401,157 @@ packages:
     engines: {node: '>=0.8.0'}
     dev: false
 
+  /escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
+    dev: true
+
   /escape-string-regexp@5.0.0:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
     dev: false
+
+  /eslint-config-prettier@9.1.0(eslint@8.57.0):
+    resolution: {integrity: sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==}
+    hasBin: true
+    peerDependencies:
+      eslint: '>=7.0.0'
+    dependencies:
+      eslint: 8.57.0
+    dev: true
+
+  /eslint-plugin-prettier@5.1.3(eslint-config-prettier@9.1.0)(eslint@8.57.0)(prettier@3.2.5):
+    resolution: {integrity: sha512-C9GCVAs4Eq7ZC/XFQHITLiHJxQngdtraXaM+LoUFoFp/lHNl2Zn8f3WQbe9HvTBBQ9YnKFB0/2Ajdqwo5D1EAw==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      '@types/eslint': '>=8.0.0'
+      eslint: '>=8.0.0'
+      eslint-config-prettier: '*'
+      prettier: '>=3.0.0'
+    peerDependenciesMeta:
+      '@types/eslint':
+        optional: true
+      eslint-config-prettier:
+        optional: true
+    dependencies:
+      eslint: 8.57.0
+      eslint-config-prettier: 9.1.0(eslint@8.57.0)
+      prettier: 3.2.5
+      prettier-linter-helpers: 1.0.0
+      synckit: 0.8.8
+    dev: true
+
+  /eslint-plugin-vue@9.22.0(eslint@8.57.0):
+    resolution: {integrity: sha512-7wCXv5zuVnBtZE/74z4yZ0CM8AjH6bk4MQGm7hZjUC2DBppKU5ioeOk5LGSg/s9a1ZJnIsdPLJpXnu1Rc+cVHg==}
+    engines: {node: ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.2.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
+      eslint: 8.57.0
+      natural-compare: 1.4.0
+      nth-check: 2.1.1
+      postcss-selector-parser: 6.0.15
+      semver: 7.6.0
+      vue-eslint-parser: 9.4.2(eslint@8.57.0)
+      xml-name-validator: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /eslint-scope@7.2.2:
+    resolution: {integrity: sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+    dev: true
+
+  /eslint-visitor-keys@3.4.3:
+    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dev: true
+
+  /eslint@8.57.0:
+    resolution: {integrity: sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    hasBin: true
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
+      '@eslint-community/regexpp': 4.10.0
+      '@eslint/eslintrc': 2.1.4
+      '@eslint/js': 8.57.0
+      '@humanwhocodes/config-array': 0.11.14
+      '@humanwhocodes/module-importer': 1.0.1
+      '@nodelib/fs.walk': 1.2.8
+      '@ungap/structured-clone': 1.2.0
+      ajv: 6.12.6
+      chalk: 4.1.2
+      cross-spawn: 7.0.3
+      debug: 4.3.4
+      doctrine: 3.0.0
+      escape-string-regexp: 4.0.0
+      eslint-scope: 7.2.2
+      eslint-visitor-keys: 3.4.3
+      espree: 9.6.1
+      esquery: 1.5.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 6.0.1
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      globals: 13.24.0
+      graphemer: 1.4.0
+      ignore: 5.3.1
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      is-path-inside: 3.0.3
+      js-yaml: 4.1.0
+      json-stable-stringify-without-jsonify: 1.0.1
+      levn: 0.4.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.2
+      natural-compare: 1.4.0
+      optionator: 0.9.3
+      strip-ansi: 6.0.1
+      text-table: 0.2.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /espree@9.6.1:
+    resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      acorn: 8.11.3
+      acorn-jsx: 5.3.2(acorn@8.11.3)
+      eslint-visitor-keys: 3.4.3
+    dev: true
 
   /esprima@4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
     hasBin: true
     dev: false
+
+  /esquery@1.5.0:
+    resolution: {integrity: sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==}
+    engines: {node: '>=0.10'}
+    dependencies:
+      estraverse: 5.3.0
+    dev: true
+
+  /esrecurse@4.3.0:
+    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
+    dependencies:
+      estraverse: 5.3.0
+    dev: true
+
+  /estraverse@5.3.0:
+    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+    engines: {node: '>=4.0'}
+    dev: true
 
   /estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
@@ -2104,6 +2562,11 @@ packages:
     dependencies:
       '@types/estree': 1.0.5
     dev: false
+
+  /esutils@2.0.3:
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
+    dev: true
 
   /etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
@@ -2152,6 +2615,14 @@ packages:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
     dev: false
 
+  /fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+    dev: true
+
+  /fast-diff@1.3.0:
+    resolution: {integrity: sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==}
+    dev: true
+
   /fast-fifo@1.3.2:
     resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
     requiresBuild: true
@@ -2167,20 +2638,32 @@ packages:
       glob-parent: 5.1.2
       merge2: 1.4.1
       micromatch: 4.0.5
-    dev: false
+
+  /fast-json-stable-stringify@2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+    dev: true
+
+  /fast-levenshtein@2.0.6:
+    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+    dev: true
 
   /fastq@1.16.0:
     resolution: {integrity: sha512-ifCoaXsDrsdkWTtiNJX5uzHDsrck5TzfKKDcuFFTIrrc/BS076qgEIfoIy1VeZqViznfKiysPYTh/QeHtnIsYA==}
     dependencies:
       reusify: 1.0.4
-    dev: false
+
+  /file-entry-cache@6.0.1:
+    resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
+    engines: {node: ^10.12.0 || >=12.0.0}
+    dependencies:
+      flat-cache: 3.2.0
+    dev: true
 
   /fill-range@7.0.1:
     resolution: {integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==}
     engines: {node: '>=8'}
     dependencies:
       to-regex-range: 5.0.1
-    dev: false
 
   /find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
@@ -2196,7 +2679,6 @@ packages:
     dependencies:
       locate-path: 6.0.0
       path-exists: 4.0.0
-    dev: false
 
   /find-yarn-workspace-root2@1.2.16:
     resolution: {integrity: sha512-hr6hb1w8ePMpPVUK39S4RlwJzi+xPLuVuG8XlwXU3KD5Yn3qgBWVfy3AzNlDhWvE1EORCE65/Qm26rFQt3VLVA==}
@@ -2204,6 +2686,19 @@ packages:
       micromatch: 4.0.5
       pkg-dir: 4.2.0
     dev: false
+
+  /flat-cache@3.2.0:
+    resolution: {integrity: sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==}
+    engines: {node: ^10.12.0 || >=12.0.0}
+    dependencies:
+      flatted: 3.3.1
+      keyv: 4.5.4
+      rimraf: 3.0.2
+    dev: true
+
+  /flatted@3.3.1:
+    resolution: {integrity: sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==}
+    dev: true
 
   /flattie@1.1.0:
     resolution: {integrity: sha512-xU99gDEnciIwJdGcBmNHnzTJ/w5AT+VFJOu6sTB6WM8diOYNA3Sa+K1DiEBQ7XH4QikQq3iFW1U+jRVcotQnBw==}
@@ -2278,6 +2773,10 @@ packages:
     dev: false
     optional: true
 
+  /fs.realpath@1.0.0:
+    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+    dev: true
+
   /fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2325,14 +2824,12 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       is-glob: 4.0.3
-    dev: false
 
   /glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
     dependencies:
       is-glob: 4.0.3
-    dev: false
 
   /glob@10.3.10:
     resolution: {integrity: sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==}
@@ -2346,14 +2843,48 @@ packages:
       path-scurry: 1.10.1
     dev: false
 
+  /glob@7.2.3:
+    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 3.1.2
+      once: 1.4.0
+      path-is-absolute: 1.0.1
+    dev: true
+
   /globals@11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
     engines: {node: '>=4'}
     dev: false
 
+  /globals@13.24.0:
+    resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}
+    engines: {node: '>=8'}
+    dependencies:
+      type-fest: 0.20.2
+    dev: true
+
+  /globby@11.1.0:
+    resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
+    engines: {node: '>=10'}
+    dependencies:
+      array-union: 2.1.0
+      dir-glob: 3.0.1
+      fast-glob: 3.3.2
+      ignore: 5.3.1
+      merge2: 1.4.1
+      slash: 3.0.0
+    dev: true
+
   /graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
     dev: false
+
+  /graphemer@1.4.0:
+    resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
+    dev: true
 
   /gray-matter@4.0.3:
     resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
@@ -2369,6 +2900,11 @@ packages:
     resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
     engines: {node: '>=4'}
     dev: false
+
+  /has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+    dev: true
 
   /hasown@2.0.0:
     resolution: {integrity: sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==}
@@ -2520,13 +3056,37 @@ packages:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
     dev: false
 
+  /ignore@5.3.1:
+    resolution: {integrity: sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==}
+    engines: {node: '>= 4'}
+    dev: true
+
+  /import-fresh@3.3.0:
+    resolution: {integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==}
+    engines: {node: '>=6'}
+    dependencies:
+      parent-module: 1.0.1
+      resolve-from: 4.0.0
+    dev: true
+
   /import-meta-resolve@4.0.0:
     resolution: {integrity: sha512-okYUR7ZQPH+efeuMJGlq4f8ubUgO50kByRPyt/Cy1Io4PSRsPjxME+YlVaCOx+NIToW7hCsZNFJyTPFFKepRSA==}
     dev: false
 
+  /imurmurhash@0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
+    dev: true
+
+  /inflight@1.0.6:
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    dependencies:
+      once: 1.4.0
+      wrappy: 1.0.2
+    dev: true
+
   /inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
-    dev: false
 
   /ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
@@ -2576,7 +3136,6 @@ packages:
   /is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
-    dev: false
 
   /is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
@@ -2588,7 +3147,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       is-extglob: 2.1.1
-    dev: false
 
   /is-inside-container@1.0.0:
     resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
@@ -2606,7 +3164,11 @@ packages:
   /is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
-    dev: false
+
+  /is-path-inside@3.0.3:
+    resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
+    engines: {node: '>=8'}
+    dev: true
 
   /is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
@@ -2632,7 +3194,6 @@ packages:
 
   /isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
-    dev: false
 
   /jackspeak@2.3.6:
     resolution: {integrity: sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==}
@@ -2669,13 +3230,24 @@ packages:
     hasBin: true
     dependencies:
       argparse: 2.0.1
-    dev: false
 
   /jsesc@2.5.2:
     resolution: {integrity: sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==}
     engines: {node: '>=4'}
     hasBin: true
     dev: false
+
+  /json-buffer@3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+    dev: true
+
+  /json-schema-traverse@0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+    dev: true
+
+  /json-stable-stringify-without-jsonify@1.0.1:
+    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+    dev: true
 
   /json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
@@ -2686,6 +3258,12 @@ packages:
   /jsonc-parser@2.3.1:
     resolution: {integrity: sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg==}
     dev: false
+
+  /keyv@4.5.4:
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+    dependencies:
+      json-buffer: 3.0.1
+    dev: true
 
   /kind-of@6.0.3:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
@@ -2701,6 +3279,14 @@ packages:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
     dev: false
+
+  /levn@0.4.1:
+    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
+    engines: {node: '>= 0.8.0'}
+    dependencies:
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+    dev: true
 
   /lilconfig@2.1.0:
     resolution: {integrity: sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==}
@@ -2738,11 +3324,13 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       p-locate: 5.0.0
-    dev: false
 
   /lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
-    dev: false
+
+  /lodash@4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+    dev: true
 
   /log-symbols@5.1.0:
     resolution: {integrity: sha512-l0x2DvrW294C9uDCoQe1VSU4gf529FkSZ6leBl4TiqZH/e+0R7hSfHQBNut2mNygDgHwvYHfFLn6Oxb3VWj2rA==}
@@ -2772,7 +3360,6 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       yallist: 4.0.0
-    dev: false
 
   /magic-string@0.30.5:
     resolution: {integrity: sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==}
@@ -2944,7 +3531,6 @@ packages:
   /merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
-    dev: false
 
   /micromark-core-commonmark@2.0.0:
     resolution: {integrity: sha512-jThOz/pVmAYUtkroV3D5c1osFXAMv9e0ypGDOIZuCeAe91/sD6BoE2Sjzt30yuXtwOYUmySOhMas/PVyh02itA==}
@@ -3199,7 +3785,6 @@ packages:
     dependencies:
       braces: 3.0.2
       picomatch: 2.3.1
-    dev: false
 
   /mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
@@ -3242,12 +3827,17 @@ packages:
     dev: false
     optional: true
 
+  /minimatch@3.1.2:
+    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
+    dependencies:
+      brace-expansion: 1.1.11
+    dev: true
+
   /minimatch@9.0.3:
     resolution: {integrity: sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==}
     engines: {node: '>=16 || 14 >=14.17'}
     dependencies:
       brace-expansion: 2.0.1
-    dev: false
 
   /minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
@@ -3272,7 +3862,6 @@ packages:
 
   /ms@2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
-    dev: false
 
   /ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -3306,6 +3895,10 @@ packages:
     requiresBuild: true
     dev: false
     optional: true
+
+  /natural-compare@1.4.0:
+    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+    dev: true
 
   /needle@2.9.1:
     resolution: {integrity: sha512-6R9fqJ5Zcmf+uYaFgdIHmLwNldn5HbK8L5ybn7Uz+ylX/rnOsSp1AHcvQSrCaFN+qNM1wpymHqD7mVasEOlHGQ==}
@@ -3383,6 +3976,12 @@ packages:
       path-key: 4.0.0
     dev: false
 
+  /nth-check@2.1.1:
+    resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
+    dependencies:
+      boolbase: 1.0.0
+    dev: true
+
   /object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -3405,8 +4004,6 @@ packages:
     requiresBuild: true
     dependencies:
       wrappy: 1.0.2
-    dev: false
-    optional: true
 
   /onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
@@ -3439,6 +4036,18 @@ packages:
       - encoding
     dev: false
 
+  /optionator@0.9.3:
+    resolution: {integrity: sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==}
+    engines: {node: '>= 0.8.0'}
+    dependencies:
+      '@aashutoshrathi/word-wrap': 1.2.6
+      deep-is: 0.1.4
+      fast-levenshtein: 2.0.6
+      levn: 0.4.1
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+    dev: true
+
   /ora@7.0.1:
     resolution: {integrity: sha512-0TUxTiFJWv+JnjWm4o9yvuskpEJLXTcng8MJuKd+SzAzp2o+OP3HWqNhB4OdJRt1Vsd9/mR0oyaEYlOnL7XIRw==}
     engines: {node: '>=16'}
@@ -3466,7 +4075,6 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       yocto-queue: 0.1.0
-    dev: false
 
   /p-limit@5.0.0:
     resolution: {integrity: sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==}
@@ -3487,7 +4095,6 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       p-limit: 3.1.0
-    dev: false
 
   /p-queue@8.0.1:
     resolution: {integrity: sha512-NXzu9aQJTAzbBqOt2hwsR63ea7yvxJc0PwN/zobNAudYfb1B7R08SzB4TsLeSbUCuG467NhnoT0oO6w1qRO+BA==}
@@ -3506,6 +4113,13 @@ packages:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
     dev: false
+
+  /parent-module@1.0.1:
+    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
+    engines: {node: '>=6'}
+    dependencies:
+      callsites: 3.1.0
+    dev: true
 
   /parse-latin@5.0.1:
     resolution: {integrity: sha512-b/K8ExXaWC9t34kKeDV8kGXBkXZ1HCSAZRYE7HR14eA1GlXX5L8iWhs8USJNhQU9q5ci413jCKF0gOyovvyRBg==}
@@ -3528,12 +4142,15 @@ packages:
   /path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
-    dev: false
+
+  /path-is-absolute@1.0.1:
+    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
+    engines: {node: '>=0.10.0'}
+    dev: true
 
   /path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
-    dev: false
 
   /path-key@4.0.0:
     resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
@@ -3556,6 +4173,11 @@ packages:
     resolution: {integrity: sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==}
     dev: false
 
+  /path-type@4.0.0:
+    resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
+    engines: {node: '>=8'}
+    dev: true
+
   /picocolors@1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
     dev: false
@@ -3563,7 +4185,6 @@ packages:
   /picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
-    dev: false
 
   /pify@2.3.0:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
@@ -3642,7 +4263,6 @@ packages:
     dependencies:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
-    dev: false
 
   /postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
@@ -3688,6 +4308,23 @@ packages:
       which-pm: 2.0.0
     dev: false
 
+  /prelude-ls@1.2.1:
+    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
+    engines: {node: '>= 0.8.0'}
+    dev: true
+
+  /prettier-linter-helpers@1.0.0:
+    resolution: {integrity: sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==}
+    engines: {node: '>=6.0.0'}
+    dependencies:
+      fast-diff: 1.3.0
+    dev: true
+
+  /prettier@3.2.5:
+    resolution: {integrity: sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==}
+    engines: {node: '>=14'}
+    hasBin: true
+
   /prismjs@1.29.0:
     resolution: {integrity: sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==}
     engines: {node: '>=6'}
@@ -3728,9 +4365,13 @@ packages:
     dev: false
     optional: true
 
+  /punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+    dev: true
+
   /queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
-    dev: false
 
   /queue-tick@1.0.1:
     resolution: {integrity: sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag==}
@@ -3879,6 +4520,11 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
+  /resolve-from@4.0.0:
+    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
+    engines: {node: '>=4'}
+    dev: true
+
   /resolve@1.22.8:
     resolution: {integrity: sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==}
     hasBin: true
@@ -3934,7 +4580,13 @@ packages:
   /reusify@1.0.4:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
-    dev: false
+
+  /rimraf@3.0.2:
+    resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
+    hasBin: true
+    dependencies:
+      glob: 7.2.3
+    dev: true
 
   /rollup@4.9.6:
     resolution: {integrity: sha512-05lzkCS2uASX0CiLFybYfVkwNbKZG5NFQ6Go0VWyogFTXXbR039UVsegViTntkk4OglHBdF54ccApXRRuXRbsg==}
@@ -3963,10 +4615,10 @@ packages:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
     dependencies:
       queue-microtask: 1.2.3
-    dev: false
 
   /safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+    requiresBuild: true
     dev: false
 
   /safer-buffer@2.1.2:
@@ -3996,7 +4648,14 @@ packages:
     hasBin: true
     dependencies:
       lru-cache: 6.0.0
-    dev: false
+
+  /semver@7.6.0:
+    resolution: {integrity: sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dependencies:
+      lru-cache: 6.0.0
+    dev: true
 
   /send@0.18.0:
     resolution: {integrity: sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==}
@@ -4048,12 +4707,10 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       shebang-regex: 3.0.0
-    dev: false
 
   /shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
-    dev: false
 
   /shikiji-core@0.9.19:
     resolution: {integrity: sha512-AFJu/vcNT21t0e6YrfadZ+9q86gvPum6iywRyt1OtIPjPFe25RQnYJyxHQPMLKCCWA992TPxmEmbNcOZCAJclw==}
@@ -4101,6 +4758,11 @@ packages:
   /sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
     dev: false
+
+  /slash@3.0.0:
+    resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
+    engines: {node: '>=8'}
+    dev: true
 
   /socket.io-adapter@2.5.4:
     resolution: {integrity: sha512-wDNHGXGewWAjQPt3pyeYBtpWSq9cLE5UW1ZUPL/2eGK9jtse/FpXib7epSTsz0Q0m+6sg6Y4KtcFTlah1bdOVg==}
@@ -4234,6 +4896,7 @@ packages:
 
   /string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+    requiresBuild: true
     dependencies:
       safe-buffer: 5.2.1
     dev: false
@@ -4250,7 +4913,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       ansi-regex: 5.0.1
-    dev: false
 
   /strip-ansi@7.1.0:
     resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
@@ -4281,6 +4943,11 @@ packages:
     dev: false
     optional: true
 
+  /strip-json-comments@3.1.1:
+    resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
+    engines: {node: '>=8'}
+    dev: true
+
   /sucrase@3.35.0:
     resolution: {integrity: sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -4302,6 +4969,13 @@ packages:
       has-flag: 3.0.0
     dev: false
 
+  /supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+    dependencies:
+      has-flag: 4.0.0
+    dev: true
+
   /supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
@@ -4310,6 +4984,14 @@ packages:
   /svg-tags@1.0.0:
     resolution: {integrity: sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==}
     dev: false
+
+  /synckit@0.8.8:
+    resolution: {integrity: sha512-HwOKAP7Wc5aRGYdKH+dw0PRRpbO841v2DENBtjnR5HFWoiNByAl7vrx3p0G/rCyYXQsrxqtX48TImFtPcIHSpQ==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    dependencies:
+      '@pkgr/core': 0.1.1
+      tslib: 2.6.2
+    dev: true
 
   /tailwindcss@3.4.1:
     resolution: {integrity: sha512-qAYmXRfk3ENzuPBakNK0SRrUDipP8NQnEY6772uDhflcQz5EhRdD7JNZxyrFHVQNCwULPBn6FNPp9brpO7ctcA==}
@@ -4386,6 +5068,10 @@ packages:
     dev: false
     optional: true
 
+  /text-table@0.2.0:
+    resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
+    dev: true
+
   /thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
     engines: {node: '>=0.8'}
@@ -4421,7 +5107,6 @@ packages:
     engines: {node: '>=8.0'}
     dependencies:
       is-number: 7.0.0
-    dev: false
 
   /toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
@@ -4440,6 +5125,15 @@ packages:
     resolution: {integrity: sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g==}
     dev: false
 
+  /ts-api-utils@1.2.1(typescript@5.3.3):
+    resolution: {integrity: sha512-RIYA36cJn2WiH9Hy77hdF9r7oEwxAtB/TS9/S4Qd90Ap4z5FSiin5zEiTL44OII1Y3IIlEvxwxFUVgrHSZ/UpA==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      typescript: '>=4.2.0'
+    dependencies:
+      typescript: 5.3.3
+    dev: true
+
   /ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
     dev: false
@@ -4456,6 +5150,10 @@ packages:
     dependencies:
       typescript: 5.3.3
     dev: false
+
+  /tslib@2.6.2:
+    resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
+    dev: true
 
   /tubechat@1.0.3:
     resolution: {integrity: sha512-djK0m9/x3za+6nMP6r8bSJElXTCXSuaVXH7heYB/xEpr0giwboih/8lY6koZcnG7V3Z1Y1AEqpWJCUxNcUH8xQ==}
@@ -4476,6 +5174,18 @@ packages:
     dev: false
     optional: true
 
+  /type-check@0.4.0:
+    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
+    engines: {node: '>= 0.8.0'}
+    dependencies:
+      prelude-ls: 1.2.1
+    dev: true
+
+  /type-fest@0.20.2:
+    resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
+    engines: {node: '>=10'}
+    dev: true
+
   /type-fest@2.19.0:
     resolution: {integrity: sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==}
     engines: {node: '>=12.20'}
@@ -4495,7 +5205,6 @@ packages:
     resolution: {integrity: sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==}
     engines: {node: '>=14.17'}
     hasBin: true
-    dev: false
 
   /undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
@@ -4613,9 +5322,14 @@ packages:
       picocolors: 1.0.0
     dev: false
 
+  /uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+    dependencies:
+      punycode: 2.3.1
+    dev: true
+
   /util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
-    dev: false
 
   /vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
@@ -4745,7 +5459,7 @@ packages:
       vscode-uri: 3.0.8
     dev: false
 
-  /volar-service-prettier@0.0.17(@volar/language-service@1.11.1):
+  /volar-service-prettier@0.0.17(@volar/language-service@1.11.1)(prettier@3.2.5):
     resolution: {integrity: sha512-YYnzZ+OT0M3Bx+xKuoAfs/uVuxk7ofz4dkZDQqjwa9iC63Ay4YGqONtmHd+xsO3lufkEBXlAQCbofDeZbSz3YQ==}
     peerDependencies:
       '@volar/language-service': ~1.11.0
@@ -4757,6 +5471,7 @@ packages:
         optional: true
     dependencies:
       '@volar/language-service': 1.11.1
+      prettier: 3.2.5
     dev: false
 
   /volar-service-typescript-twoslash-queries@0.0.17(@volar/language-service@1.11.1):
@@ -4846,6 +5561,24 @@ packages:
     resolution: {integrity: sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw==}
     dev: false
 
+  /vue-eslint-parser@9.4.2(eslint@8.57.0):
+    resolution: {integrity: sha512-Ry9oiGmCAK91HrKMtCrKFWmSFWvYkpGglCeFAIqDdr9zdXmMMpJOmUJS7WWsW7fX81h6mwHmUZCQQ1E0PkSwYQ==}
+    engines: {node: ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: '>=6.0.0'
+    dependencies:
+      debug: 4.3.4
+      eslint: 8.57.0
+      eslint-scope: 7.2.2
+      eslint-visitor-keys: 3.4.3
+      espree: 9.6.1
+      esquery: 1.5.0
+      lodash: 4.17.21
+      semver: 7.5.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /vue@3.4.15(typescript@5.3.3):
     resolution: {integrity: sha512-jC0GH4KkWLWJOEQjOpkqU1bQsBwf4R1rsFtw5GQJbjHVKWDzO6P0nWWBTmjp1xSemAioDFj1jdaK1qa3DnMQoQ==}
     peerDependencies:
@@ -4914,7 +5647,6 @@ packages:
     hasBin: true
     dependencies:
       isexe: 2.0.0
-    dev: false
 
   /widest-line@4.0.1:
     resolution: {integrity: sha512-o0cyEG0e8GPzT4iGHphIOh0cJOV8fivsXxddQasHPHfoZf1ZexrfeA21w2NaEN1RHE+fXlfISmOE8R9N3u3Qig==}
@@ -4944,8 +5676,6 @@ packages:
   /wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
     requiresBuild: true
-    dev: false
-    optional: true
 
   /ws@8.11.0:
     resolution: {integrity: sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==}
@@ -4973,6 +5703,11 @@ packages:
         optional: true
     dev: false
 
+  /xml-name-validator@4.0.0:
+    resolution: {integrity: sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==}
+    engines: {node: '>=12'}
+    dev: true
+
   /xmlhttprequest-ssl@2.0.0:
     resolution: {integrity: sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A==}
     engines: {node: '>=0.4.0'}
@@ -4989,7 +5724,6 @@ packages:
 
   /yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
-    dev: false
 
   /yaml@2.3.4:
     resolution: {integrity: sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA==}
@@ -5017,7 +5751,6 @@ packages:
   /yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
-    dev: false
 
   /yocto-queue@1.0.0:
     resolution: {integrity: sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==}

--- a/src/actions/ask.ts
+++ b/src/actions/ask.ts
@@ -4,37 +4,35 @@ import config from '@/config'
 const getPathname = () => new URL(window.location.href).pathname
 const { peopleAllowedToAsk } = config
 
-export default async function (options:any) {
-  const pathname = getPathname()
+export default async function (options: any) {
+	const pathname = getPathname()
 
-  if(pathname != '/ask')
-    return
+	if (pathname != '/ask') return
 
-  if(!peopleAllowedToAsk.includes(options.tags.username))
-    return
+	if (!peopleAllowedToAsk.includes(options.tags.username)) return
 
-  const { message } = options
+	const { message } = options
 
-  store.ask.messages.push({
-    user: 'k1d',
-    message
-  })
+	store.ask.messages.push({
+		user: 'k1d',
+		message
+	})
 
-  console.log('k1d: ' + message)
-  await new Promise(res => setTimeout(() => 
-  res(''), 6000))
+	console.log('k1d: ' + message)
+	await new Promise(res => setTimeout(() => res(''), 6000))
 
-  try {
-    const response = await fetch('http://localhost:4321/api/bot/?q=' + message)
-    .then(res => res.json()) as { content: string}
+	try {
+		const response = (await fetch(
+			'http://localhost:4321/api/bot/?q=' + message
+		).then(res => res.json())) as { content: string }
 
-    console.log('bot: ' + response.content)
+		console.log('bot: ' + response.content)
 
-    store.ask.messages.push({
-      user: 'therealdevthales',
-      message: response.content
-    })
-  } catch (error) {
-    console.error("Erro ao chamar a API da OpenAI:", error);
-  }
+		store.ask.messages.push({
+			user: 'therealdevthales',
+			message: response.content
+		})
+	} catch (error) {
+		console.error('Erro ao chamar a API da OpenAI:', error)
+	}
 }

--- a/src/actions/ask.ts
+++ b/src/actions/ask.ts
@@ -5,34 +5,34 @@ const getPathname = () => new URL(window.location.href).pathname
 const { peopleAllowedToAsk } = config
 
 export default async function (options: any) {
-	const pathname = getPathname()
+  const pathname = getPathname()
 
-	if (pathname != '/ask') return
+  if (pathname != '/ask') return
 
-	if (!peopleAllowedToAsk.includes(options.tags.username)) return
+  if (!peopleAllowedToAsk.includes(options.tags.username)) return
 
-	const { message } = options
+  const { message } = options
 
-	store.ask.messages.push({
-		user: 'k1d',
-		message
-	})
+  store.ask.messages.push({
+    user: 'k1d',
+    message
+  })
 
-	console.log('k1d: ' + message)
-	await new Promise(res => setTimeout(() => res(''), 6000))
+  console.log('k1d: ' + message)
+  await new Promise(res => setTimeout(() => res(''), 6000))
 
-	try {
-		const response = (await fetch(
-			'http://localhost:4321/api/bot/?q=' + message
-		).then(res => res.json())) as { content: string }
+  try {
+    const response = (await fetch(
+      'http://localhost:4321/api/bot/?q=' + message
+    ).then(res => res.json())) as { content: string }
 
-		console.log('bot: ' + response.content)
+    console.log('bot: ' + response.content)
 
-		store.ask.messages.push({
-			user: 'therealdevthales',
-			message: response.content
-		})
-	} catch (error) {
-		console.error('Erro ao chamar a API da OpenAI:', error)
-	}
+    store.ask.messages.push({
+      user: 'therealdevthales',
+      message: response.content
+    })
+  } catch (error) {
+    console.error('Erro ao chamar a API da OpenAI:', error)
+  }
 }

--- a/src/actions/confetti.ts
+++ b/src/actions/confetti.ts
@@ -6,20 +6,20 @@ const jsConfetti = new JSConfetti()
 const getParams = () => new URL(window.location.href).searchParams
 
 export default function () {
-	const params = getParams()
+  const params = getParams()
 
-	if (!params.get('confetti')) return
+  if (!params.get('confetti')) return
 
-	const theSound = {
-		id: String(Date.now()),
-		src: 'cheering.mp3'
-	}
+  const theSound = {
+    id: String(Date.now()),
+    src: 'cheering.mp3'
+  }
 
-	store.sfx.push(theSound)
+  store.sfx.push(theSound)
 
-	jsConfetti.addConfetti()
+  jsConfetti.addConfetti()
 
-	setTimeout(() => {
-		store.sfx.splice(store.sfx.indexOf(theSound), 1)
-	}, 6000)
+  setTimeout(() => {
+    store.sfx.splice(store.sfx.indexOf(theSound), 1)
+  }, 6000)
 }

--- a/src/actions/confetti.ts
+++ b/src/actions/confetti.ts
@@ -5,22 +5,21 @@ const jsConfetti = new JSConfetti()
 
 const getParams = () => new URL(window.location.href).searchParams
 
-export default function (options:any) {
-  const params = getParams()
+export default function () {
+	const params = getParams()
 
-  if(!params.get('confetti'))
-    return
+	if (!params.get('confetti')) return
 
-  const theSound = { 
-    id: String(Date.now()),
-    src: 'cheering.mp3' 
-  }
-  
-  store.sfx.push(theSound)
+	const theSound = {
+		id: String(Date.now()),
+		src: 'cheering.mp3'
+	}
 
-  jsConfetti.addConfetti()
+	store.sfx.push(theSound)
 
-  setTimeout(() => {
-    store.sfx.splice(store.sfx.indexOf(theSound), 1)
-  }, 6000)
+	jsConfetti.addConfetti()
+
+	setTimeout(() => {
+		store.sfx.splice(store.sfx.indexOf(theSound), 1)
+	}, 6000)
 }

--- a/src/actions/errou.ts
+++ b/src/actions/errou.ts
@@ -2,20 +2,19 @@ import { store } from '@/store'
 
 const getParams = () => new URL(window.location.href).searchParams
 
-export default function (options:any) {
-  const params = getParams()
+export default function () {
+	const params = getParams()
 
-  if(!params.get('errou'))
-    return
+	if (!params.get('errou')) return
 
-  const theSound = { 
-    id: String(Date.now()),
-    src: 'erroou.mp3' 
-  }
-  
-  store.sfx.push(theSound)
+	const theSound = {
+		id: String(Date.now()),
+		src: 'erroou.mp3'
+	}
 
-  setTimeout(() => {
-    store.sfx.splice(store.sfx.indexOf(theSound), 1)
-  }, 2000)
+	store.sfx.push(theSound)
+
+	setTimeout(() => {
+		store.sfx.splice(store.sfx.indexOf(theSound), 1)
+	}, 2000)
 }

--- a/src/actions/errou.ts
+++ b/src/actions/errou.ts
@@ -3,18 +3,18 @@ import { store } from '@/store'
 const getParams = () => new URL(window.location.href).searchParams
 
 export default function () {
-	const params = getParams()
+  const params = getParams()
 
-	if (!params.get('errou')) return
+  if (!params.get('errou')) return
 
-	const theSound = {
-		id: String(Date.now()),
-		src: 'erroou.mp3'
-	}
+  const theSound = {
+    id: String(Date.now()),
+    src: 'erroou.mp3'
+  }
 
-	store.sfx.push(theSound)
+  store.sfx.push(theSound)
 
-	setTimeout(() => {
-		store.sfx.splice(store.sfx.indexOf(theSound), 1)
-	}, 2000)
+  setTimeout(() => {
+    store.sfx.splice(store.sfx.indexOf(theSound), 1)
+  }, 2000)
 }

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -3,7 +3,7 @@ import errou from './errou'
 import ask from './ask'
 
 export default {
-	errou,
-	confetti,
-	ask
+  errou,
+  confetti,
+  ask
 }

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -3,7 +3,7 @@ import errou from './errou'
 import ask from './ask'
 
 export default {
-  errou,
-  confetti,
-  ask
+	errou,
+	confetti,
+	ask
 }

--- a/src/components/SoundEffects.vue
+++ b/src/components/SoundEffects.vue
@@ -1,44 +1,44 @@
 <template>
-  <audio
-    :data-id="effect.id"
-    v-if="effect.src"
-    ref="audioFile"
-    :src="`/sounds/${effect.src}`"
-  />
+	<audio
+		:data-id="effect.id"
+		v-if="effect.src"
+		ref="audioFile"
+		:src="`/sounds/${effect.src}`"
+	/>
 </template>
 
 <script>
-  export default {
-    props: {
-      effect: {
-        type: Object,
-        required: true
-      }
-    },
+export default {
+	props: {
+		effect: {
+			type: Object,
+			required: true
+		}
+	},
 
-    mounted() {
-      if (this.effect.src) {
-        const sound = this.$refs.audioFile;
-        sound.addEventListener("ended", () => {
-          sound.src = "";
-          this.$emit("ended");
-          const remover = setTimeout(() => {
-            this.removeSelf()
-            clearInterval(remover)
-          }, 1000)
-        });
+	mounted() {
+		if (this.effect.src) {
+			const sound = this.$refs.audioFile
+			sound.addEventListener('ended', () => {
+				sound.src = ''
+				this.$emit('ended')
+				const remover = setTimeout(() => {
+					this.removeSelf()
+					clearInterval(remover)
+				}, 1000)
+			})
 
-        sound.play().catch(error => {
-          console.log("failed to play sound", error);
-          this.$emit("ended");
-        });
-      }
-    },
+			sound.play().catch(error => {
+				console.log('failed to play sound', error)
+				this.$emit('ended')
+			})
+		}
+	},
 
-    methods: {
-      removeSelf() {
-        this.$el?.parentNode?.removeChild(this.$el);
-      }
-    }
-  };
+	methods: {
+		removeSelf() {
+			this.$el?.parentNode?.removeChild(this.$el)
+		}
+	}
+}
 </script>

--- a/src/components/SoundEffects.vue
+++ b/src/components/SoundEffects.vue
@@ -1,44 +1,44 @@
 <template>
-	<audio
-		:data-id="effect.id"
-		v-if="effect.src"
-		ref="audioFile"
-		:src="`/sounds/${effect.src}`"
-	/>
+  <audio
+    :data-id="effect.id"
+    v-if="effect.src"
+    ref="audioFile"
+    :src="`/sounds/${effect.src}`"
+  />
 </template>
 
 <script>
 export default {
-	props: {
-		effect: {
-			type: Object,
-			required: true
-		}
-	},
+  props: {
+    effect: {
+      type: Object,
+      required: true
+    }
+  },
 
-	mounted() {
-		if (this.effect.src) {
-			const sound = this.$refs.audioFile
-			sound.addEventListener('ended', () => {
-				sound.src = ''
-				this.$emit('ended')
-				const remover = setTimeout(() => {
-					this.removeSelf()
-					clearInterval(remover)
-				}, 1000)
-			})
+  mounted() {
+    if (this.effect.src) {
+      const sound = this.$refs.audioFile
+      sound.addEventListener('ended', () => {
+        sound.src = ''
+        this.$emit('ended')
+        const remover = setTimeout(() => {
+          this.removeSelf()
+          clearInterval(remover)
+        }, 1000)
+      })
 
-			sound.play().catch(error => {
-				console.log('failed to play sound', error)
-				this.$emit('ended')
-			})
-		}
-	},
+      sound.play().catch(error => {
+        console.log('failed to play sound', error)
+        this.$emit('ended')
+      })
+    }
+  },
 
-	methods: {
-		removeSelf() {
-			this.$el?.parentNode?.removeChild(this.$el)
-		}
-	}
+  methods: {
+    removeSelf() {
+      this.$el?.parentNode?.removeChild(this.$el)
+    }
+  }
 }
 </script>

--- a/src/components/StreamAskChat.vue
+++ b/src/components/StreamAskChat.vue
@@ -1,93 +1,90 @@
-
 <template>
-  <div 
-    ref="messageWrapper" 
-    class="message-wrapper p-1 w-screen">
-    <div class="inner p-4 text-gray-400 relative bg-gray-900 text-lg">
-      <div 
-      class="text-gray-100 mb-2 text-xs uppercase">
-        {{ user }}
-      </div>
-      <p>{{ message }}</p>
-    </div>
-  </div>
+	<div ref="messageWrapper" class="message-wrapper p-1 w-screen">
+		<div class="inner p-4 text-gray-400 relative bg-gray-900 text-lg">
+			<div class="text-gray-100 mb-2 text-xs uppercase">
+				{{ user }}
+			</div>
+			<p>{{ message }}</p>
+		</div>
+	</div>
 </template>
 
 <script>
 export default {
-  props: {
-    message: {
-      type: String,
-      required: true
-    },
-    user: {
-      type: String,
-      required: false
-    },
-    extra: {
-      type: Object,
-      required: false
-    }
-  },
-  mounted() {
-    this.$nextTick(() => {
-      setTimeout(() => this.$refs.messageWrapper?.classList.add('visible'), 100)
-    });
+	props: {
+		message: {
+			type: String,
+			required: true
+		},
+		user: {
+			type: String,
+			required: false
+		},
+		extra: {
+			type: Object,
+			required: false
+		}
+	},
+	mounted() {
+		this.$nextTick(() => {
+			setTimeout(() => this.$refs.messageWrapper?.classList.add('visible'), 100)
+		})
 
-    const removeTimer = setTimeout(() => {
-      this.removeSelf();
-      clearTimeout(removeTimer);
-    }, 21000);
-  },
+		const removeTimer = setTimeout(() => {
+			this.removeSelf()
+			clearTimeout(removeTimer)
+		}, 21000)
+	},
 
-  methods: {
-    removeSelf() {
-      this.$el.parentNode.removeChild(this.$el);
-    }
-  }
-};
+	methods: {
+		removeSelf() {
+			this.$el.parentNode.removeChild(this.$el)
+		}
+	}
+}
 </script>
 
 <style scoped>
 .message-wrapper {
-  --outline-width: 4px;
-  /* overflow: hidden; */
-  opacity: 0;
-  transition: opacity 300ms, margin-top 300ms;
-  font-family: "Press Start 2P", sans-serif;
+	--outline-width: 4px;
+	/* overflow: hidden; */
+	opacity: 0;
+	transition:
+		opacity 300ms,
+		margin-top 300ms;
+	font-family: 'Press Start 2P', sans-serif;
 }
 
 .inner:after,
 .inner:before {
-  content: '';
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  box-sizing: content-box;
+	content: '';
+	position: absolute;
+	width: 100%;
+	height: 100%;
+	box-sizing: content-box;
 }
 
 .inner:before {
-  top: calc(0px - var(--outline-width));
-  left: 0;
-  /* left: calc(0 - var(--outline-width)); */
-  border-top: var(--outline-width) white solid;
-  border-bottom: var(--outline-width) white solid;
+	top: calc(0px - var(--outline-width));
+	left: 0;
+	/* left: calc(0 - var(--outline-width)); */
+	border-top: var(--outline-width) white solid;
+	border-bottom: var(--outline-width) white solid;
 }
 
 .inner::after {
-  left: calc(0px - var(--outline-width));
-  top: 0;
-  border-left: var(--outline-width) white solid;
-  border-right: var(--outline-width) white solid;
+	left: calc(0px - var(--outline-width));
+	top: 0;
+	border-left: var(--outline-width) white solid;
+	border-right: var(--outline-width) white solid;
 }
 
 .message-wrapper.visible {
-  opacity: 1;
-  margin-top: 10px;
+	opacity: 1;
+	margin-top: 10px;
 }
 
 .inner {
-  overflow-wrap: break-word;
+	overflow-wrap: break-word;
 }
-
 </style>

--- a/src/components/StreamAskChat.vue
+++ b/src/components/StreamAskChat.vue
@@ -1,90 +1,90 @@
 <template>
-	<div ref="messageWrapper" class="message-wrapper p-1 w-screen">
-		<div class="inner p-4 text-gray-400 relative bg-gray-900 text-lg">
-			<div class="text-gray-100 mb-2 text-xs uppercase">
-				{{ user }}
-			</div>
-			<p>{{ message }}</p>
-		</div>
-	</div>
+  <div ref="messageWrapper" class="message-wrapper p-1 w-screen">
+    <div class="inner p-4 text-gray-400 relative bg-gray-900 text-lg">
+      <div class="text-gray-100 mb-2 text-xs uppercase">
+        {{ user }}
+      </div>
+      <p>{{ message }}</p>
+    </div>
+  </div>
 </template>
 
 <script>
 export default {
-	props: {
-		message: {
-			type: String,
-			required: true
-		},
-		user: {
-			type: String,
-			required: false
-		},
-		extra: {
-			type: Object,
-			required: false
-		}
-	},
-	mounted() {
-		this.$nextTick(() => {
-			setTimeout(() => this.$refs.messageWrapper?.classList.add('visible'), 100)
-		})
+  props: {
+    message: {
+      type: String,
+      required: true
+    },
+    user: {
+      type: String,
+      required: false
+    },
+    extra: {
+      type: Object,
+      required: false
+    }
+  },
+  mounted() {
+    this.$nextTick(() => {
+      setTimeout(() => this.$refs.messageWrapper?.classList.add('visible'), 100)
+    })
 
-		const removeTimer = setTimeout(() => {
-			this.removeSelf()
-			clearTimeout(removeTimer)
-		}, 21000)
-	},
+    const removeTimer = setTimeout(() => {
+      this.removeSelf()
+      clearTimeout(removeTimer)
+    }, 21000)
+  },
 
-	methods: {
-		removeSelf() {
-			this.$el.parentNode.removeChild(this.$el)
-		}
-	}
+  methods: {
+    removeSelf() {
+      this.$el.parentNode.removeChild(this.$el)
+    }
+  }
 }
 </script>
 
 <style scoped>
 .message-wrapper {
-	--outline-width: 4px;
-	/* overflow: hidden; */
-	opacity: 0;
-	transition:
-		opacity 300ms,
-		margin-top 300ms;
-	font-family: 'Press Start 2P', sans-serif;
+  --outline-width: 4px;
+  /* overflow: hidden; */
+  opacity: 0;
+  transition:
+    opacity 300ms,
+    margin-top 300ms;
+  font-family: 'Press Start 2P', sans-serif;
 }
 
 .inner:after,
 .inner:before {
-	content: '';
-	position: absolute;
-	width: 100%;
-	height: 100%;
-	box-sizing: content-box;
+  content: '';
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  box-sizing: content-box;
 }
 
 .inner:before {
-	top: calc(0px - var(--outline-width));
-	left: 0;
-	/* left: calc(0 - var(--outline-width)); */
-	border-top: var(--outline-width) white solid;
-	border-bottom: var(--outline-width) white solid;
+  top: calc(0px - var(--outline-width));
+  left: 0;
+  /* left: calc(0 - var(--outline-width)); */
+  border-top: var(--outline-width) white solid;
+  border-bottom: var(--outline-width) white solid;
 }
 
 .inner::after {
-	left: calc(0px - var(--outline-width));
-	top: 0;
-	border-left: var(--outline-width) white solid;
-	border-right: var(--outline-width) white solid;
+  left: calc(0px - var(--outline-width));
+  top: 0;
+  border-left: var(--outline-width) white solid;
+  border-right: var(--outline-width) white solid;
 }
 
 .message-wrapper.visible {
-	opacity: 1;
-	margin-top: 10px;
+  opacity: 1;
+  margin-top: 10px;
 }
 
 .inner {
-	overflow-wrap: break-word;
+  overflow-wrap: break-word;
 }
 </style>

--- a/src/components/StreamChat.vue
+++ b/src/components/StreamChat.vue
@@ -1,116 +1,119 @@
-
 <template>
-  <div 
-    ref="messageWrapper" 
-    class="message-wrapper p-1 w-screen">
-    <div class="inner p-4 text-gray-400 relative bg-gray-900 text-lg">
-      <div 
-      class="text-gray-100 mb-2 text-xs uppercase">
-        {{ user }}
-      </div>
-      <p v-html="messageWithEmotes" />
-    </div>
-  </div>
+	<div ref="messageWrapper" class="message-wrapper p-1 w-screen">
+		<div class="inner p-4 text-gray-400 relative bg-gray-900 text-lg">
+			<div class="text-gray-100 mb-2 text-xs uppercase">
+				{{ user }}
+			</div>
+			<p v-html="messageWithEmotes" />
+		</div>
+	</div>
 </template>
 
 <script>
 export default {
-  props: {
-    message: {
-      type: String,
-      required: true
-    },
-    user: {
-      type: String,
-      required: true
-    },
-    extra: {
-      type: Object,
-      required: false
-    }
-  },
-  mounted() {
-    this.$nextTick(() => {
-      setTimeout(() => this.$refs.messageWrapper?.classList.add('visible'), 100)
-    });
-  },
-  methods: {
+	props: {
+		message: {
+			type: String,
+			required: true
+		},
+		user: {
+			type: String,
+			required: true
+		},
+		extra: {
+			type: Object,
+			required: false
+		}
+	},
+	mounted() {
+		this.$nextTick(() => {
+			setTimeout(() => this.$refs.messageWrapper?.classList.add('visible'), 100)
+		})
+	},
+	methods: {
 		/**
 		 * @description This function replaces all < and > with safe HTML characters to prevent XSS attacks
 		 * @param {string} message
 		 * @returns {string}
 		 * */
 		sanitizeMessage(message) {
-			return message.replace(/</g, '&lt;').replace(/>/g, '&gt;');
+			return message.replace(/</g, '&lt;').replace(/>/g, '&gt;')
 		}
 	},
-  computed: {
-    messageWithEmotes() {
-      let message = this.sanitizeMessage(this.message)
+	computed: {
+		messageWithEmotes() {
+			let message = this.sanitizeMessage(this.message)
 
-      const messageEmotes = this.extra.emotes
-      const replaceBetween = ({start, end, img, message}) => message.substring(0, start) + img + message.substring(end);
-      const imgEmote = (src) => `<img class="inline-block w-8" src="${src}"/>`
-      const emoteURL = (emoteId) => `https://static-cdn.jtvnw.net/emoticons/v1/${emoteId}/3.0`
+			const messageEmotes = this.extra.emotes
+			const replaceBetween = ({ start, end, img, message }) =>
+				message.substring(0, start) + img + message.substring(end)
+			const imgEmote = src => `<img class="inline-block w-8" src="${src}"/>`
+			const emoteURL = emoteId =>
+				`https://static-cdn.jtvnw.net/emoticons/v1/${emoteId}/3.0`
 
-      if (messageEmotes) {
-        const emotes = Object.keys(messageEmotes)
-        for (let emote of emotes) {
-          let reversedMessageEmotes = messageEmotes[emote].toReversed()
-          for (let i = 0; i < reversedMessageEmotes.length; i++) {
-            let img = imgEmote(emoteURL(emote))
-            let [start, end] = reversedMessageEmotes[i].split('-')
-            message = replaceBetween({start, end: Number(end) + 1, img, message})
-          }
-        }
-      }
-      return message
-    },
-  }
-
-};
+			if (messageEmotes) {
+				const emotes = Object.keys(messageEmotes)
+				for (let emote of emotes) {
+					let reversedMessageEmotes = messageEmotes[emote].toReversed()
+					for (let i = 0; i < reversedMessageEmotes.length; i++) {
+						let img = imgEmote(emoteURL(emote))
+						let [start, end] = reversedMessageEmotes[i].split('-')
+						message = replaceBetween({
+							start,
+							end: Number(end) + 1,
+							img,
+							message
+						})
+					}
+				}
+			}
+			return message
+		}
+	}
+}
 </script>
 
 <style scoped>
 .message-wrapper {
-  --outline-width: 4px;
-  /* overflow: hidden; */
-  opacity: 0;
-  transition: opacity 300ms, margin-top 300ms;
-  font-family: "Press Start 2P", sans-serif;
+	--outline-width: 4px;
+	/* overflow: hidden; */
+	opacity: 0;
+	transition:
+		opacity 300ms,
+		margin-top 300ms;
+	font-family: 'Press Start 2P', sans-serif;
 }
 
 .inner:after,
 .inner:before {
-  content: '';
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  box-sizing: content-box;
+	content: '';
+	position: absolute;
+	width: 100%;
+	height: 100%;
+	box-sizing: content-box;
 }
 
 .inner:before {
-  top: calc(0px - var(--outline-width));
-  left: 0;
-  /* left: calc(0 - var(--outline-width)); */
-  border-top: var(--outline-width) white solid;
-  border-bottom: var(--outline-width) white solid;
+	top: calc(0px - var(--outline-width));
+	left: 0;
+	/* left: calc(0 - var(--outline-width)); */
+	border-top: var(--outline-width) white solid;
+	border-bottom: var(--outline-width) white solid;
 }
 
 .inner::after {
-  left: calc(0px - var(--outline-width));
-  top: 0;
-  border-left: var(--outline-width) white solid;
-  border-right: var(--outline-width) white solid;
+	left: calc(0px - var(--outline-width));
+	top: 0;
+	border-left: var(--outline-width) white solid;
+	border-right: var(--outline-width) white solid;
 }
 
 .message-wrapper.visible {
-  opacity: 1;
-  margin-top: 10px;
+	opacity: 1;
+	margin-top: 10px;
 }
 
 .inner {
-  overflow-wrap: break-word;
+	overflow-wrap: break-word;
 }
-
 </style>

--- a/src/components/StreamChat.vue
+++ b/src/components/StreamChat.vue
@@ -1,119 +1,119 @@
 <template>
-	<div ref="messageWrapper" class="message-wrapper p-1 w-screen">
-		<div class="inner p-4 text-gray-400 relative bg-gray-900 text-lg">
-			<div class="text-gray-100 mb-2 text-xs uppercase">
-				{{ user }}
-			</div>
-			<p v-html="messageWithEmotes" />
-		</div>
-	</div>
+  <div ref="messageWrapper" class="message-wrapper p-1 w-screen">
+    <div class="inner p-4 text-gray-400 relative bg-gray-900 text-lg">
+      <div class="text-gray-100 mb-2 text-xs uppercase">
+        {{ user }}
+      </div>
+      <p v-html="messageWithEmotes" />
+    </div>
+  </div>
 </template>
 
 <script>
 export default {
-	props: {
-		message: {
-			type: String,
-			required: true
-		},
-		user: {
-			type: String,
-			required: true
-		},
-		extra: {
-			type: Object,
-			required: false
-		}
-	},
-	mounted() {
-		this.$nextTick(() => {
-			setTimeout(() => this.$refs.messageWrapper?.classList.add('visible'), 100)
-		})
-	},
-	methods: {
-		/**
-		 * @description This function replaces all < and > with safe HTML characters to prevent XSS attacks
-		 * @param {string} message
-		 * @returns {string}
-		 * */
-		sanitizeMessage(message) {
-			return message.replace(/</g, '&lt;').replace(/>/g, '&gt;')
-		}
-	},
-	computed: {
-		messageWithEmotes() {
-			let message = this.sanitizeMessage(this.message)
+  props: {
+    message: {
+      type: String,
+      required: true
+    },
+    user: {
+      type: String,
+      required: true
+    },
+    extra: {
+      type: Object,
+      required: false
+    }
+  },
+  mounted() {
+    this.$nextTick(() => {
+      setTimeout(() => this.$refs.messageWrapper?.classList.add('visible'), 100)
+    })
+  },
+  methods: {
+    /**
+     * @description This function replaces all < and > with safe HTML characters to prevent XSS attacks
+     * @param {string} message
+     * @returns {string}
+     * */
+    sanitizeMessage(message) {
+      return message.replace(/</g, '&lt;').replace(/>/g, '&gt;')
+    }
+  },
+  computed: {
+    messageWithEmotes() {
+      let message = this.sanitizeMessage(this.message)
 
-			const messageEmotes = this.extra.emotes
-			const replaceBetween = ({ start, end, img, message }) =>
-				message.substring(0, start) + img + message.substring(end)
-			const imgEmote = src => `<img class="inline-block w-8" src="${src}"/>`
-			const emoteURL = emoteId =>
-				`https://static-cdn.jtvnw.net/emoticons/v1/${emoteId}/3.0`
+      const messageEmotes = this.extra.emotes
+      const replaceBetween = ({ start, end, img, message }) =>
+        message.substring(0, start) + img + message.substring(end)
+      const imgEmote = src => `<img class="inline-block w-8" src="${src}"/>`
+      const emoteURL = emoteId =>
+        `https://static-cdn.jtvnw.net/emoticons/v1/${emoteId}/3.0`
 
-			if (messageEmotes) {
-				const emotes = Object.keys(messageEmotes)
-				for (let emote of emotes) {
-					let reversedMessageEmotes = messageEmotes[emote].toReversed()
-					for (let i = 0; i < reversedMessageEmotes.length; i++) {
-						let img = imgEmote(emoteURL(emote))
-						let [start, end] = reversedMessageEmotes[i].split('-')
-						message = replaceBetween({
-							start,
-							end: Number(end) + 1,
-							img,
-							message
-						})
-					}
-				}
-			}
-			return message
-		}
-	}
+      if (messageEmotes) {
+        const emotes = Object.keys(messageEmotes)
+        for (let emote of emotes) {
+          let reversedMessageEmotes = messageEmotes[emote].toReversed()
+          for (let i = 0; i < reversedMessageEmotes.length; i++) {
+            let img = imgEmote(emoteURL(emote))
+            let [start, end] = reversedMessageEmotes[i].split('-')
+            message = replaceBetween({
+              start,
+              end: Number(end) + 1,
+              img,
+              message
+            })
+          }
+        }
+      }
+      return message
+    }
+  }
 }
 </script>
 
 <style scoped>
 .message-wrapper {
-	--outline-width: 4px;
-	/* overflow: hidden; */
-	opacity: 0;
-	transition:
-		opacity 300ms,
-		margin-top 300ms;
-	font-family: 'Press Start 2P', sans-serif;
+  --outline-width: 4px;
+  /* overflow: hidden; */
+  opacity: 0;
+  transition:
+    opacity 300ms,
+    margin-top 300ms;
+  font-family: 'Press Start 2P', sans-serif;
 }
 
 .inner:after,
 .inner:before {
-	content: '';
-	position: absolute;
-	width: 100%;
-	height: 100%;
-	box-sizing: content-box;
+  content: '';
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  box-sizing: content-box;
 }
 
 .inner:before {
-	top: calc(0px - var(--outline-width));
-	left: 0;
-	/* left: calc(0 - var(--outline-width)); */
-	border-top: var(--outline-width) white solid;
-	border-bottom: var(--outline-width) white solid;
+  top: calc(0px - var(--outline-width));
+  left: 0;
+  /* left: calc(0 - var(--outline-width)); */
+  border-top: var(--outline-width) white solid;
+  border-bottom: var(--outline-width) white solid;
 }
 
 .inner::after {
-	left: calc(0px - var(--outline-width));
-	top: 0;
-	border-left: var(--outline-width) white solid;
-	border-right: var(--outline-width) white solid;
+  left: calc(0px - var(--outline-width));
+  top: 0;
+  border-left: var(--outline-width) white solid;
+  border-right: var(--outline-width) white solid;
 }
 
 .message-wrapper.visible {
-	opacity: 1;
-	margin-top: 10px;
+  opacity: 1;
+  margin-top: 10px;
 }
 
 .inner {
-	overflow-wrap: break-word;
+  overflow-wrap: break-word;
 }
 </style>

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,4 @@
 export default {
-  channels: ["maykbrito"],
-  peopleAllowedToAsk: ["maykbrito"],
+	channels: ['maykbrito'],
+	peopleAllowedToAsk: ['maykbrito']
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,4 @@
 export default {
-	channels: ['maykbrito'],
-	peopleAllowedToAsk: ['maykbrito']
+  channels: ['maykbrito'],
+  peopleAllowedToAsk: ['maykbrito']
 }

--- a/src/pages/api/bot.ts
+++ b/src/pages/api/bot.ts
@@ -1,36 +1,43 @@
-import type { APIRoute } from "astro";
-import { OpenAI } from "openai";
+import type { APIRoute } from 'astro'
+import { OpenAI } from 'openai'
 
 const openai = new OpenAI({
-  apiKey: import.meta.env.OPENAI_KEY,
-});
+	apiKey: import.meta.env.OPENAI_KEY
+})
 
 const systemContent = `
 Imagine que você é um personagem fictício que dá respostas que misture sabedoria falsa, um toque de cinismo e uma pitada de sarcasmo para as perguntas feitas. Lembre-se, estamos aqui para entreter, não para ofender. Esteja preparado para responder da maneira mais 'iluminada' possível, afinal, quem precisa de sucesso real quando se pode ter uma resposta hilariamente fictícia? Use no máximo 120 caracteres para sua resposta.`
 
-export const create = async (prompt: string) => await openai.chat.completions.create({
-  model: "gpt-3.5-turbo",
-  messages: [
-    {"role": "system", "content": systemContent}, 
-    {role: "user", content: prompt},
-  ],
-  max_tokens: 100,
-});
+export const create = async (prompt: string) =>
+	await openai.chat.completions.create({
+		model: 'gpt-3.5-turbo',
+		messages: [
+			{ role: 'system', content: systemContent },
+			{ role: 'user', content: prompt }
+		],
+		max_tokens: 100
+	})
 
-export const GET: APIRoute = async ({request}) => {
-  const params = new URL(request.url)
-  const q = params.searchParams.get('q')
+export const GET: APIRoute = async ({ request }) => {
+	const params = new URL(request.url)
+	const q = params.searchParams.get('q')
 
-  if(!q) {
-    return new Response(JSON.stringify({ message: 'param q is necessary'}), { status: 400 })
-  }
-  
-  const completion = await create(q)
-  const { choices } = completion
+	if (!q) {
+		return new Response(
+			JSON.stringify({
+				message: 'param q is necessary'
+			}),
+			{ status: 400 }
+		)
+	}
 
-  return new Response(JSON.stringify({
-    content: choices[0].message.content
-  }), {
-    status:200
-  })
+	const completion = await create(q)
+	const { choices } = completion
+
+	return new Response(
+		JSON.stringify({
+			content: choices[0].message.content
+		}),
+		{ status: 200 }
+	)
 }

--- a/src/pages/api/bot.ts
+++ b/src/pages/api/bot.ts
@@ -2,42 +2,42 @@ import type { APIRoute } from 'astro'
 import { OpenAI } from 'openai'
 
 const openai = new OpenAI({
-	apiKey: import.meta.env.OPENAI_KEY
+  apiKey: import.meta.env.OPENAI_KEY
 })
 
 const systemContent = `
 Imagine que você é um personagem fictício que dá respostas que misture sabedoria falsa, um toque de cinismo e uma pitada de sarcasmo para as perguntas feitas. Lembre-se, estamos aqui para entreter, não para ofender. Esteja preparado para responder da maneira mais 'iluminada' possível, afinal, quem precisa de sucesso real quando se pode ter uma resposta hilariamente fictícia? Use no máximo 120 caracteres para sua resposta.`
 
 export const create = async (prompt: string) =>
-	await openai.chat.completions.create({
-		model: 'gpt-3.5-turbo',
-		messages: [
-			{ role: 'system', content: systemContent },
-			{ role: 'user', content: prompt }
-		],
-		max_tokens: 100
-	})
+  await openai.chat.completions.create({
+    model: 'gpt-3.5-turbo',
+    messages: [
+      { role: 'system', content: systemContent },
+      { role: 'user', content: prompt }
+    ],
+    max_tokens: 100
+  })
 
 export const GET: APIRoute = async ({ request }) => {
-	const params = new URL(request.url)
-	const q = params.searchParams.get('q')
+  const params = new URL(request.url)
+  const q = params.searchParams.get('q')
 
-	if (!q) {
-		return new Response(
-			JSON.stringify({
-				message: 'param q is necessary'
-			}),
-			{ status: 400 }
-		)
-	}
+  if (!q) {
+    return new Response(
+      JSON.stringify({
+        message: 'param q is necessary'
+      }),
+      { status: 400 }
+    )
+  }
 
-	const completion = await create(q)
-	const { choices } = completion
+  const completion = await create(q)
+  const { choices } = completion
 
-	return new Response(
-		JSON.stringify({
-			content: choices[0].message.content
-		}),
-		{ status: 200 }
-	)
+  return new Response(
+    JSON.stringify({
+      content: choices[0].message.content
+    }),
+    { status: 200 }
+  )
 }

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,18 +1,18 @@
 import { reactive } from 'vue'
 
 interface SfxProps {
-	src: string
-	id?: string
-	volume?: number
-	loop?: boolean
+  src: string
+  id?: string
+  volume?: number
+  loop?: boolean
 }
 
 export const store = reactive({
-	chat: {
-		messages: <any>[]
-	},
-	ask: {
-		messages: <any>[]
-	},
-	sfx: [] as SfxProps[]
+  chat: {
+    messages: <any>[]
+  },
+  ask: {
+    messages: <any>[]
+  },
+  sfx: [] as SfxProps[]
 })

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,18 +1,18 @@
 import { reactive } from 'vue'
 
 interface SfxProps {
-  src: string
-  id?: string
-  volume?: number
-  loop?: boolean
+	src: string
+	id?: string
+	volume?: number
+	loop?: boolean
 }
 
 export const store = reactive({
-  chat: {
-    messages: <any>[]
-  },
-  ask: {
-    messages: <any>[]
-  },
-  sfx: [] as SfxProps[]
+	chat: {
+		messages: <any>[]
+	},
+	ask: {
+		messages: <any>[]
+	},
+	sfx: [] as SfxProps[]
 })

--- a/src/tmi.ts
+++ b/src/tmi.ts
@@ -8,28 +8,28 @@ type ActionKey = keyof typeof actions
 import { store } from '@/store'
 
 const client = new tmi.Client({
-	channels: config.channels
+  channels: config.channels
 })
 
 client.connect()
 
 client.on('message', (channel: string, tags: any, message: string) => {
-	handleAction(message, tags, channel)
+  handleAction(message, tags, channel)
 
-	store.chat.messages.push({
-		channel,
-		user: tags.username,
-		message,
-		extra: tags
-	})
+  store.chat.messages.push({
+    channel,
+    user: tags.username,
+    message,
+    extra: tags
+  })
 })
 
 const handleAction = (message: string, tags: any, channel: string) => {
-	if (message.startsWith('!')) {
-		const action = message.split(' ')[0].replace('!', '') as ActionKey
+  if (message.startsWith('!')) {
+    const action = message.split(' ')[0].replace('!', '') as ActionKey
 
-		const messageWithoutAction = message.replace('!' + action, '')
-		actions[action] &&
-			actions[action]({ message: messageWithoutAction, tags, client, channel })
-	}
+    const messageWithoutAction = message.replace('!' + action, '')
+    actions[action] &&
+      actions[action]({ message: messageWithoutAction, tags, client, channel })
+  }
 }

--- a/src/tmi.ts
+++ b/src/tmi.ts
@@ -1,7 +1,6 @@
-import tmi from 'tmi.js';
-import config from './config';
-import actions from './actions/index';
-
+import tmi from 'tmi.js'
+import config from './config'
+import actions from './actions/index'
 
 // https://bobbyhadz.com/blog/typescript-access-object-property-dynamically
 type ActionKey = keyof typeof actions
@@ -9,27 +8,28 @@ type ActionKey = keyof typeof actions
 import { store } from '@/store'
 
 const client = new tmi.Client({
-  channels: config.channels
+	channels: config.channels
 })
 
 client.connect()
 
-client.on('message', (channel:string, tags:any, message:string) => {
-  handleAction(message, tags, channel)
+client.on('message', (channel: string, tags: any, message: string) => {
+	handleAction(message, tags, channel)
 
-  store.chat.messages.push({
-    channel,
-    user: tags.username, 
-    message, 
-    extra: tags
-  })
+	store.chat.messages.push({
+		channel,
+		user: tags.username,
+		message,
+		extra: tags
+	})
 })
 
-const handleAction = (message: string, tags:any, channel: string) => {
-  if(message.startsWith('!')) {
-    const action = message.split(' ')[0].replace('!', '') as ActionKey
+const handleAction = (message: string, tags: any, channel: string) => {
+	if (message.startsWith('!')) {
+		const action = message.split(' ')[0].replace('!', '') as ActionKey
 
-    const messageWithoutAction = message.replace('!' + action, '')
-    actions[action] && actions[action]({message: messageWithoutAction, tags, client, channel})
-  }
+		const messageWithoutAction = message.replace('!' + action, '')
+		actions[action] &&
+			actions[action]({ message: messageWithoutAction, tags, client, channel })
+	}
 }

--- a/src/views/AskView.vue
+++ b/src/views/AskView.vue
@@ -1,14 +1,14 @@
 <template>
-	<div class="chat-wrapper w-screen h-screen">
-		<div id="chat" ref="messagesWrapper" class="grid bottom-1 absolute">
-			<StreamAskChat
-				v-for="({ message, user }, index) in messages"
-				:key="index"
-				:user="user"
-				:message="message"
-			/>
-		</div>
-	</div>
+  <div class="chat-wrapper w-screen h-screen">
+    <div id="chat" ref="messagesWrapper" class="grid bottom-1 absolute">
+      <StreamAskChat
+        v-for="({ message, user }, index) in messages"
+        :key="index"
+        :user="user"
+        :message="message"
+      />
+    </div>
+  </div>
 </template>
 
 <script>
@@ -16,30 +16,30 @@ import StreamAskChat from '@/components/StreamAskChat.vue'
 import { store } from '@/store'
 
 export default {
-	components: {
-		StreamAskChat
-	},
-	mounted() {
-		this.$nextTick(() => {
-			const url = new URL(window.location)
-			const params = url.searchParams
-			if (params?.get('horizontal')) {
-				this.$refs?.messagesWrapper?.classList.add('horizontal')
-			}
-		})
-	},
-	computed: {
-		messages() {
-			return store.ask.messages
-		}
-	}
+  components: {
+    StreamAskChat
+  },
+  mounted() {
+    this.$nextTick(() => {
+      const url = new URL(window.location)
+      const params = url.searchParams
+      if (params?.get('horizontal')) {
+        this.$refs?.messagesWrapper?.classList.add('horizontal')
+      }
+    })
+  },
+  computed: {
+    messages() {
+      return store.ask.messages
+    }
+  }
 }
 </script>
 
 <style scoped>
 .chat-wrapper {
-	--mask: linear-gradient(transparent, rgb(0 0 0 / 100%) 30%);
-	-webkit-mask-image: var(--mask);
-	mask-image: var(--mask);
+  --mask: linear-gradient(transparent, rgb(0 0 0 / 100%) 30%);
+  -webkit-mask-image: var(--mask);
+  mask-image: var(--mask);
 }
 </style>

--- a/src/views/AskView.vue
+++ b/src/views/AskView.vue
@@ -1,48 +1,45 @@
 <template>
-  <div class="chat-wrapper w-screen h-screen">
-    <div id="chat" ref="messagesWrapper" 
-      class="grid bottom-1 absolute">
-      <StreamAskChat 
-      v-for="({message, user}, index) in messages"
-      :key="index"
-      :user="user"
-      :message="message"
-      />
-    </div>
-  </div>
+	<div class="chat-wrapper w-screen h-screen">
+		<div id="chat" ref="messagesWrapper" class="grid bottom-1 absolute">
+			<StreamAskChat
+				v-for="({ message, user }, index) in messages"
+				:key="index"
+				:user="user"
+				:message="message"
+			/>
+		</div>
+	</div>
 </template>
 
 <script>
-import StreamAskChat from "@/components/StreamAskChat.vue";
-import { store } from "@/store"
+import StreamAskChat from '@/components/StreamAskChat.vue'
+import { store } from '@/store'
 
 export default {
-  components: {
-    StreamAskChat,
-  },
-
-  mounted() {
-    this.$nextTick(() => {
-      const url = new URL(window.location)
-      const params = url.searchParams
-      if(params?.get('horizontal')) {
-        this.$refs?.messagesWrapper?.classList.add('horizontal')
-      }
-    })
-  },
-  computed: {
-    messages() {
-      return store.ask.messages
-    }
-  },
-};
+	components: {
+		StreamAskChat
+	},
+	mounted() {
+		this.$nextTick(() => {
+			const url = new URL(window.location)
+			const params = url.searchParams
+			if (params?.get('horizontal')) {
+				this.$refs?.messagesWrapper?.classList.add('horizontal')
+			}
+		})
+	},
+	computed: {
+		messages() {
+			return store.ask.messages
+		}
+	}
+}
 </script>
-
 
 <style scoped>
 .chat-wrapper {
-  --mask: linear-gradient(transparent, rgb(0 0 0 / 100%) 30%);
-  -webkit-mask-image: var(--mask);
-  mask-image: var(--mask); 
+	--mask: linear-gradient(transparent, rgb(0 0 0 / 100%) 30%);
+	-webkit-mask-image: var(--mask);
+	mask-image: var(--mask);
 }
 </style>

--- a/src/views/ChatView.vue
+++ b/src/views/ChatView.vue
@@ -1,15 +1,15 @@
 <template>
-	<div class="chat-wrapper w-screen h-screen">
-		<div id="chat" ref="messagesWrapper" class="grid bottom-1 absolute">
-			<StreamChat
-				v-for="({ message, user, extra }, index) in messages"
-				:key="index"
-				:message="message"
-				:user="user"
-				:extra="extra"
-			/>
-		</div>
-	</div>
+  <div class="chat-wrapper w-screen h-screen">
+    <div id="chat" ref="messagesWrapper" class="grid bottom-1 absolute">
+      <StreamChat
+        v-for="({ message, user, extra }, index) in messages"
+        :key="index"
+        :message="message"
+        :user="user"
+        :extra="extra"
+      />
+    </div>
+  </div>
 </template>
 
 <script>
@@ -17,30 +17,30 @@ import StreamChat from '@/components/StreamChat.vue'
 import { store } from '@/store'
 
 export default {
-	components: {
-		StreamChat
-	},
-	mounted() {
-		this.$nextTick(() => {
-			const url = new URL(window.location)
-			const params = url.searchParams
-			if (params?.get('horizontal')) {
-				this.$refs?.messagesWrapper?.classList.add('horizontal')
-			}
-		})
-	},
-	computed: {
-		messages() {
-			return store.chat.messages
-		}
-	}
+  components: {
+    StreamChat
+  },
+  mounted() {
+    this.$nextTick(() => {
+      const url = new URL(window.location)
+      const params = url.searchParams
+      if (params?.get('horizontal')) {
+        this.$refs?.messagesWrapper?.classList.add('horizontal')
+      }
+    })
+  },
+  computed: {
+    messages() {
+      return store.chat.messages
+    }
+  }
 }
 </script>
 
 <style scoped>
 .chat-wrapper {
-	--mask: linear-gradient(transparent, rgb(0 0 0 / 100%) 30%);
-	-webkit-mask-image: var(--mask);
-	mask-image: var(--mask);
+  --mask: linear-gradient(transparent, rgb(0 0 0 / 100%) 30%);
+  -webkit-mask-image: var(--mask);
+  mask-image: var(--mask);
 }
 </style>

--- a/src/views/ChatView.vue
+++ b/src/views/ChatView.vue
@@ -1,49 +1,46 @@
 <template>
-  <div class="chat-wrapper w-screen h-screen">
-    <div id="chat" ref="messagesWrapper" 
-      class="grid bottom-1 absolute">
-      <StreamChat 
-      v-for="({message, user, extra}, index) in messages"
-      :key="index"
-      :message="message"
-      :user="user"
-      :extra="extra"
-      />
-    </div>
-  </div>
+	<div class="chat-wrapper w-screen h-screen">
+		<div id="chat" ref="messagesWrapper" class="grid bottom-1 absolute">
+			<StreamChat
+				v-for="({ message, user, extra }, index) in messages"
+				:key="index"
+				:message="message"
+				:user="user"
+				:extra="extra"
+			/>
+		</div>
+	</div>
 </template>
 
 <script>
-import StreamChat from "@/components/StreamChat.vue";
-import { store } from "@/store"
+import StreamChat from '@/components/StreamChat.vue'
+import { store } from '@/store'
 
 export default {
-  components: {
-    StreamChat,
-  },
-
-  mounted() {
-    this.$nextTick(() => {
-      const url = new URL(window.location)
-      const params = url.searchParams
-      if(params?.get('horizontal')) {
-        this.$refs?.messagesWrapper?.classList.add('horizontal')
-      }
-    })
-  },
-  computed: {
-    messages() {
-      return store.chat.messages
-    }
-  },
-};
+	components: {
+		StreamChat
+	},
+	mounted() {
+		this.$nextTick(() => {
+			const url = new URL(window.location)
+			const params = url.searchParams
+			if (params?.get('horizontal')) {
+				this.$refs?.messagesWrapper?.classList.add('horizontal')
+			}
+		})
+	},
+	computed: {
+		messages() {
+			return store.chat.messages
+		}
+	}
+}
 </script>
-
 
 <style scoped>
 .chat-wrapper {
-  --mask: linear-gradient(transparent, rgb(0 0 0 / 100%) 30%);
-  -webkit-mask-image: var(--mask);
-  mask-image: var(--mask); 
+	--mask: linear-gradient(transparent, rgb(0 0 0 / 100%) 30%);
+	-webkit-mask-image: var(--mask);
+	mask-image: var(--mask);
 }
 </style>

--- a/src/views/GlobalSfx.vue
+++ b/src/views/GlobalSfx.vue
@@ -1,10 +1,10 @@
 <template>
-	<SoundEffects
-		v-for="(sfx, index) in effects"
-		:key="index"
-		:effect="sfx"
-		v-on:ended="sfxEnded"
-	/>
+  <SoundEffects
+    v-for="(sfx, index) in effects"
+    :key="index"
+    :effect="sfx"
+    v-on:ended="sfxEnded"
+  />
 </template>
 
 <script>
@@ -12,13 +12,13 @@ import SoundEffects from '@/components/SoundEffects.vue'
 import { store } from '@/store'
 
 export default {
-	components: {
-		SoundEffects
-	},
-	computed: {
-		effects() {
-			return store.sfx
-		}
-	}
+  components: {
+    SoundEffects
+  },
+  computed: {
+    effects() {
+      return store.sfx
+    }
+  }
 }
 </script>

--- a/src/views/GlobalSfx.vue
+++ b/src/views/GlobalSfx.vue
@@ -1,25 +1,24 @@
 <template>
-  <SoundEffects
-    v-for="(sfx, index) in effects"
-    :key="index"
-    :effect="sfx"
-    v-on:ended="sfxEnded"
-  />
+	<SoundEffects
+		v-for="(sfx, index) in effects"
+		:key="index"
+		:effect="sfx"
+		v-on:ended="sfxEnded"
+	/>
 </template>
 
 <script>
- import SoundEffects from '@/components/SoundEffects.vue';
- import { store } from "@/store"
+import SoundEffects from '@/components/SoundEffects.vue'
+import { store } from '@/store'
 
- export default {
-  components: {
-    SoundEffects,
-  },
-
-  computed: {
-    effects() {
-      return store.sfx
-    }
-  },
- }
+export default {
+	components: {
+		SoundEffects
+	},
+	computed: {
+		effects() {
+			return store.sfx
+		}
+	}
+}
 </script>

--- a/src/ws.js
+++ b/src/ws.js
@@ -8,15 +8,15 @@ tubeChat.connect('maykbrito')
 const server = httpServer.createServer()
 
 const io = new Server(server, {
-	cors: {
-		origin: 'http://localhost:8485'
-	}
+  cors: {
+    origin: 'http://localhost:8485'
+  }
 })
 
 const onConnection = socket => {
-	tubeChat.on('message', ({ message, name }) => {
-		socket.emit('chat', { name, message })
-	})
+  tubeChat.on('message', ({ message, name }) => {
+    socket.emit('chat', { name, message })
+  })
 }
 
 io.on('connection', onConnection)

--- a/src/ws.js
+++ b/src/ws.js
@@ -8,18 +8,17 @@ tubeChat.connect('maykbrito')
 const server = httpServer.createServer()
 
 const io = new Server(server, {
-  cors: {
-    origin: "http://localhost:8485"
-  }
+	cors: {
+		origin: 'http://localhost:8485'
+	}
 })
 
-const onConnection = (socket) => {
-  tubeChat.on('message', ({ badges, channel, channelId, color, id, isMembership, isModerator, isNewMember, isOwner, isVerified, message, name, thumbnail, timestamp }) => {
-    socket.emit('chat', {name, message})
-  })
+const onConnection = socket => {
+	tubeChat.on('message', ({ message, name }) => {
+		socket.emit('chat', { name, message })
+	})
 }
 
-io.on("connection", onConnection)
+io.on('connection', onConnection)
 
 server.listen(3333)
-

--- a/src/yt.ts
+++ b/src/yt.ts
@@ -1,28 +1,27 @@
 import { io, Socket } from 'socket.io-client'
-import actions from './actions/index';
+import actions from './actions/index'
 
 type ActionKey = keyof typeof actions
 
 let socket: Socket | null = null
 
 if (!socket) {
-  socket = io("http://localhost:3333")
+	socket = io('http://localhost:3333')
 
-  socket.on("chat", (data) => {
-    handleAction(data)
-  })
+	socket.on('chat', data => {
+		handleAction(data)
+	})
 }
 
 const handleAction = (data: any) => {
-  let { message } = data
-  message = message[0].text
+	let { message } = data
+	message = message[0].text
 
-  if(message.startsWith('!')) {
+	if (message.startsWith('!')) {
+		const action = message.split(' ')[0].replace('!', '') as ActionKey
 
-    const action = message.split(' ')[0].replace('!', '') as ActionKey
+		const messageWithoutAction = message.replace('!' + action, '')
 
-    const messageWithoutAction = message.replace('!' + action, '')
-
-    actions[action] && actions[action]({message: messageWithoutAction, data})
-  }
+		actions[action] && actions[action]({ message: messageWithoutAction, data })
+	}
 }

--- a/src/yt.ts
+++ b/src/yt.ts
@@ -6,22 +6,22 @@ type ActionKey = keyof typeof actions
 let socket: Socket | null = null
 
 if (!socket) {
-	socket = io('http://localhost:3333')
+  socket = io('http://localhost:3333')
 
-	socket.on('chat', data => {
-		handleAction(data)
-	})
+  socket.on('chat', data => {
+    handleAction(data)
+  })
 }
 
 const handleAction = (data: any) => {
-	let { message } = data
-	message = message[0].text
+  let { message } = data
+  message = message[0].text
 
-	if (message.startsWith('!')) {
-		const action = message.split(' ')[0].replace('!', '') as ActionKey
+  if (message.startsWith('!')) {
+    const action = message.split(' ')[0].replace('!', '') as ActionKey
 
-		const messageWithoutAction = message.replace('!' + action, '')
+    const messageWithoutAction = message.replace('!' + action, '')
 
-		actions[action] && actions[action]({ message: messageWithoutAction, data })
-	}
+    actions[action] && actions[action]({ message: messageWithoutAction, data })
+  }
 }

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -1,8 +1,8 @@
 /** @type {import('tailwindcss').Config} */
 export default {
-	content: ['./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}'],
-	theme: {
-		extend: {}
-	},
-	plugins: []
+  content: ['./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}'],
+  theme: {
+    extend: {}
+  },
+  plugins: []
 }

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -2,7 +2,7 @@
 export default {
 	content: ['./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}'],
 	theme: {
-		extend: {},
+		extend: {}
 	},
-	plugins: [],
+	plugins: []
 }


### PR DESCRIPTION
# Motivação da alteração

Essa decisão foi tomada principalmente porque eu estava fazendo as alterações dos demais PRs e o Prettier do meu VSCode usa um padrão diferente do que estava sendo usado no projeto, fazendo com que o código  fosse formato de outra forma e gerasse muitas alterações desnecessárias, então resolvi já configurar pra não gerar muitas alterações de estilo em contribuições futuras.

As configurações que utilizei são algumas que costumo usar em projetos com Vue e TypeScript, mudando apenas a regra do ponto e vírgula, mas obviamente você pode customizar com o code style que está mais acostumado.

Além disso, adicionei os scripts `lint` e `lint:fix` no `package.json` para facilitar a formatação de todos os arquivos do projeto quando for necessário.

Essa modificação não mexe em nenhuma lógica, todas as alterações em arquivos são relacionadas apenas à formatação do código