### PR TITLE
Adição da configuração de canal do YouTube + pequena refatoração no arquivo de configurações

### DIFF
--- a/src/actions/ask.ts
+++ b/src/actions/ask.ts
@@ -1,5 +1,6 @@
 import { store } from '@/store'
-import config from '@/config'
+import { config } from '@/config'
+
 const getPathname = () => new URL(window.location.href).pathname
 const { peopleAllowedToAsk } = config
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,5 @@
-export default {
-  channels: ['maykbrito'],
+export const config = {
+  twitchChannelName: 'maykbrito',
+  youtubeChannelName: 'maykbrito',
   peopleAllowedToAsk: ['maykbrito']
 }

--- a/src/pages/api/youtube-chat.ts
+++ b/src/pages/api/youtube-chat.ts
@@ -3,9 +3,10 @@ import type { MessageEvent } from 'tubechat/lib/types'
 import { TubeChat } from 'tubechat'
 
 import type { MessageEventData } from '@/actions'
+import { config } from '@/config'
 
 const tubeChat = new TubeChat()
-tubeChat.connect('maykbrito')
+tubeChat.connect(config.youtubeChannelName)
 
 export const GET: APIRoute = async () => {
   let handleNewTubeChatMessage: MessageEvent

--- a/src/tmi.ts
+++ b/src/tmi.ts
@@ -1,11 +1,11 @@
 import tmi from 'tmi.js'
 import type { MessageEventData } from '@/actions'
 import { handleMessageEvent } from '@/actions'
-import config from '@/config'
+import { config } from '@/config'
 import { store } from '@/store'
 
 const client = new tmi.Client({
-  channels: config.channels
+  channels: [config.twitchChannelName]
 })
 
 client.connect()


### PR DESCRIPTION
Esta alteração é focada em adicionar a configuração do canal que o TubeChat deve usar para buscar as mensagens da live.

Além de adicionar essa nova configuração fiz algumas alterações para deixar o código mais explícito, ao renomear algumas propriedades já existentes, e torná-lo mais fácil de ser consumido, alterando o export default para um export nomeado (que facilita o autocomplete na hora de usar esse objeto em outro arquivo).

Agora o objeto de configuração tem o seguinte formato:

```ts
export const config = {
  twitchChannelName: 'maykbrito',
  youtubeChannelName: 'maykbrito',
  peopleAllowedToAsk: ['maykbrito']
}
```